### PR TITLE
検索画面と検索結果画面を整理

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,6 +1,7 @@
 @import "reset";
-@import "modules/comics";
+@import "modules/authors";
 @import "font-awesome-sprockets";
 @import "font-awesome";
 @import "modules/flash";
 @import "modules/kaminari";
+@import "modules/comics";

--- a/app/assets/stylesheets/modules/authors.scss
+++ b/app/assets/stylesheets/modules/authors.scss
@@ -1,0 +1,206 @@
+* {
+  box-sizing: border-box;
+}
+
+
+
+
+.wrapper {
+  display: block;
+  background-color: #f5f5f5;
+  a {
+    color: black;
+    text-decoration: none;
+  }
+}
+
+// ヘッダーのCSS
+.header {
+  height: auto;
+  &__up {
+    display: flex;
+    align-items: flex-end;
+    border-bottom: solid 1px silver;
+    padding: 10px 40px 10px;
+    &__left {
+      margin-right: auto;
+      width: 70%;
+      font-size: 20px;
+      line-height: 1.5em;
+      text-align: center;
+      overflow: hidden;
+    }
+    &__left span{
+      display: inline-block;
+      padding-left: 100%;
+      white-space: nowrap;
+      line-height: 1em;
+      animation: scrollAnime 17s linear infinite;
+    }
+    @keyframes scrollAnime{
+        0% { transform: translateX(0)}
+      100% { transform: translateX(-100%)}
+    }
+    &__right {
+      ul {
+        display: flex;
+        .btn {
+          margin-left: 10px;
+          font-size: 16px;
+        }
+        .btn:hover {
+          color: lightcoral;
+        }
+      }
+    }
+  }
+
+  &__under {
+    margin-top: 20px;
+    padding: 10px;
+    .app-title__box {
+      font-size: 50px;
+      font-weight: bold;
+      text-align: center;
+      a {
+        padding: 20px;
+        background-color: #71dd9e;
+        border-radius: 50px;
+        color: white;
+      }
+    }
+  }
+}
+
+
+//ヘッダーの下のCSS
+.top {
+  padding: 20px 100px 40px;
+  height: auto;
+  display: flex;
+}
+
+
+//トップ内の左のCSS
+.main {
+  background-color: #e2dfdf;
+  width: 70%;
+  height: auto;
+  margin-bottom: 40px;
+  padding: 5px;
+  border-radius: 3px;
+  .select {
+    padding-top: 4px;
+    &__list {
+      display: flex;
+      .list__type {
+        background-color: #e2dfdf;
+        margin-left: 50px;
+        padding: 10px;
+        border-radius: 10px 10px 0 0;
+        a {
+          font-size: 20px;
+          font-weight: bold;
+          text-decoration: none;
+        }
+      }
+      .inactive__btn:hover {
+        opacity: 0.5;
+        background-color: rgb(160, 233, 196);
+      }
+      .active__btn {
+        background-color: white;
+      }
+    }
+  }
+  .display {
+    background-color: white;
+    height: calc(100% - 65px);
+    padding: 40px 100px;
+    .comic-box {
+      text-decoration: none;
+      margin-bottom: 30px;
+      padding: 5px;
+      border-bottom: 1px solid lightgreen;
+      &__link {
+        font-size: 20px;
+        text-decoration: none;
+      }
+      &__data {
+        display: flex;
+        justify-content: space-between;
+      }
+      .comic-box__data:hover {
+        color: lightcoral;
+      }
+    }
+  }
+}
+
+
+//トップ内の右のサイドバーCSS
+.side {
+  background-color: #f5f5f5;
+  margin-left: 30px;
+  width: 30%;
+  &__up {
+    height: 50vh;
+    text-align: center;
+    background-color: white;
+    padding: 30px 0;
+    border: solid 2px #e2dfdf;
+    border-radius: 3px;
+    &__title {
+      font-size: 20px;
+      margin-bottom: 10px;
+      span {
+        border-bottom: solid 3px red;
+      }
+    }
+    &__image {
+      height: 300px;
+      width: 200px;
+      object-fit: scale-down;
+      border: dashed 1px rgb(226, 234, 236);
+    }
+    &__list {
+      display: flex;
+      justify-content: center;
+      &__btn{
+        margin-left: 5px;
+        .circle__btn {
+          color: red;
+        }
+      }
+    }
+  }
+
+  &__under {
+    background-color: white;
+    height: 500px;
+    margin-top: 10px;
+    padding: 40px;
+    text-align: center;
+    border: solid 2px #e2dfdf;
+    border-radius: 3px;
+    p {
+      font-size: 24px;
+      span {
+        border-bottom: solid 3px red;
+      }
+    }
+    &__list {
+      overflow: auto;
+      &__notice {
+        margin-bottom: 15px;
+        .notice__date {
+          text-align: left;
+          padding-left: 100px;
+        }
+      }
+      a:hover {
+        color: lightcoral;
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/modules/authors.scss
+++ b/app/assets/stylesheets/modules/authors.scss
@@ -117,21 +117,28 @@
     background-color: white;
     height: calc(100% - 65px);
     padding: 40px 100px;
-    .comic-box {
-      text-decoration: none;
-      margin-bottom: 30px;
-      padding: 5px;
-      border-bottom: 1px solid lightgreen;
-      &__link {
-        font-size: 20px;
+    .comics__all-box {
+      .comics__all {
+        font-size: 24px;
+        color: rgb(147, 224, 147);
+        margin-bottom: 30px;
+      }
+      .comic-box {
         text-decoration: none;
-      }
-      &__data {
-        display: flex;
-        justify-content: space-between;
-      }
-      .comic-box__data:hover {
-        color: lightcoral;
+        margin-bottom: 30px;
+        padding: 5px;
+        border-bottom: 1px solid lightgreen;
+        &__link {
+          font-size: 20px;
+          text-decoration: none;
+        }
+        &__data {
+          display: flex;
+          justify-content: space-between;
+        }
+        .comic-box__data:hover {
+          color: lightcoral;
+        }
       }
     }
   }

--- a/app/assets/stylesheets/modules/comics.scss
+++ b/app/assets/stylesheets/modules/comics.scss
@@ -75,17 +75,103 @@
 
 //検索結果のCSS
 
-.search-result__box {
-  .search-result {
-    font-size: 24px;
-    color: rgb(147, 224, 147);
-    margin-bottom: 30px;
-  }
 
-  ul {
-    .search-result__count {
+.display__search {
+  background-color: white;
+  height: calc(100% - 65px);
+  padding: 40px 40px;
+
+  .search-result__box {
+    .search-result {
+      font-size: 28px;
+      color: rgb(147, 224, 147);
+      margin-bottom: 30px;
+      padding-left: 40px;
+    }
+
+    ul {
+      .search-result__count {
+        font-size: 20px;
+        margin-bottom: 40px;
+        padding-left: 50px;
+      }
+      .comics-box__list {
+        display: grid;
+        grid-template-columns: repeat(2, 1fr);
+        grid-template-rows: repeat(5 1fr);
+        justify-items: center;
+        align-items: center;
+        .comic-box__result {
+          width: 320px;
+          height: 360px;
+          padding: 10px;
+          // border: dashed 1px lightgray;
+          position: relative;
+          .up-left {
+            width: 80px;
+            height: 50px;
+            position: absolute;
+            left: 0;
+            top: 0;
+            border-left: solid 1px rgb(217, 243, 217);
+            border-top: solid 1px rgb(217, 243, 217);
+          }
+          .under-right {
+            width: 80px;
+            height: 50px;
+            position: absolute;
+            right: 0;
+            bottom: 20px;
+            border-right: solid 1px rgb(217, 243, 217);
+            border-bottom: solid 1px rgb(217, 243, 217);
+          }
+          &__data {
+            display: flex;
+            margin-bottom: 15px;
+            .comic__result__image {
+              margin-right: 20px;
+              img {
+                width: 120px;
+                height: 192px;
+                object-fit: scale-down;
+                // border: dashed 1px lawngreen;
+              }
+            }
+            .comic__result__name__list {
+              max-width: 160px;
+              word-wrap:break-word;
+              .comic__result__name {
+                font-size: 16px;
+                margin: 10px 0;
+              }
+              .comic__result__author-name {
+                font-size: 16px;
+              }
+            }
+          }
+          &__summary {
+            padding: 0 20px 0;
+            max-height: 120px;
+            max-width: 300px;
+            display: -webkit-box;
+            -webkit-box-orient: vertical;
+            -webkit-line-clamp: 4;
+            overflow: hidden;
+          }
+        }
+      }
+      .displayed__results {
+        font-size: 18px;
+        margin-bottom: 40px;
+        padding-left: 50px;
+        color: #8a8282;
+      }
+    }
+
+    .no__search-result {
       font-size: 20px;
-      margin-bottom: 20px;
+      margin-bottom: 40px;
+      padding-left: 50px;
     }
   }
 }

--- a/app/assets/stylesheets/modules/comics.scss
+++ b/app/assets/stylesheets/modules/comics.scss
@@ -1,201 +1,91 @@
-* {
-  box-sizing: border-box;
-}
+//検索画面のCSS（comics/index.html）
 
-
-
-
-.wrapper {
-  display: block;
-  background-color: #f5f5f5;
-  a {
-    color: black;
-    text-decoration: none;
+.search-box {
+  p {
+    font-size: 24px;
+    color: rgb(147, 224, 147);
+    margin-bottom: 30px;
   }
-}
 
-.header {
-  height: auto;
-  &__up {
-    display: flex;
-    align-items: flex-end;
-    border-bottom: solid 1px silver;
-    padding: 10px 40px 10px;
-    &__left {
-      margin-right: auto;
-      width: 70%;
-      font-size: 20px;
-      line-height: 1.5em;
-      text-align: center;
-      overflow: hidden;
-    }
-    &__left span{
-      display: inline-block;
-      padding-left: 100%;
-      white-space: nowrap;
-      line-height: 1em;
-      animation: scrollAnime 17s linear infinite;
-    }
-    @keyframes scrollAnime{
-        0% { transform: translateX(0)}
-      100% { transform: translateX(-100%)}
-    }
-    &__right {
-      ul {
-        display: flex;
-        .btn {
-          margin-left: 10px;
-          font-size: 16px;
-        }
-        .btn:hover {
-          color: lightcoral;
-        }
-      }
+  label {
+    font-size: 20px;
+  }
+
+  &__word {
+    margin-bottom: 30px;
+    #q_name_or_author_name_cont {
+      width: 100%;
+      height: 40px;
+      margin-top: 10px;
+      padding: 0 10px;
     }
   }
 
-  &__under {
-    margin-top: 20px;
-    padding: 10px;
-    .app-title__box {
-      font-size: 50px;
+  &__genre {
+    margin-bottom: 30px;
+    #q_genres_id_eq {
+      width: 100%;
+      height: 40px;
+      margin-top: 10px;
+      padding: 0 10px;
+    }
+  }
+
+  &__number-of-books {
+    margin-bottom: 30px;
+    #q_number_of_books_gteq {
+      height: 40px;
+      width: 120px;
+      margin-top: 10px;
+      padding: 0 10px;
+    }
+
+    .wavy-line {
       font-weight: bold;
-      text-align: center;
-      a {
-        padding: 20px;
-        background-color: #71dd9e;
-        border-radius: 50px;
-        color: white;
-      }
-    }
-  }
-}
-
-
-.top {
-  padding: 20px 100px 40px;
-  height: auto;
-  display: flex;
-}
-
-
-.main {
-  background-color: #e2dfdf;
-  width: 70%;
-  height: auto;
-  margin-bottom: 40px;
-  padding: 5px;
-  border-radius: 3px;
-  .select {
-    padding-top: 4px;
-    &__list {
-      display: flex;
-      .list__type {
-        background-color: #e2dfdf;
-        margin-left: 50px;
-        padding: 10px;
-        border-radius: 10px 10px 0 0;
-        a {
-          font-size: 20px;
-          font-weight: bold;
-          text-decoration: none;
-        }
-      }
-      .inactive__btn:hover {
-        opacity: 0.5;
-        background-color: rgb(160, 233, 196);
-      }
-      .active__btn {
-        background-color: white;
-      }
-    }
-  }
-  .display {
-    background-color: white;
-    height: calc(100% - 65px);
-    padding: 40px 100px;
-    .comic-box {
-      text-decoration: none;
-      margin-bottom: 30px;
-      padding: 5px;
-      border-bottom: 1px solid lightgreen;
-      &__link {
-        font-size: 20px;
-        text-decoration: none;
-      }
-      &__data {
-        display: flex;
-        justify-content: space-between;
-      }
-      .comic-box__data:hover {
-        color: lightcoral;
-      }
-    }
-  }
-}
-
-.side {
-  background-color: #f5f5f5;
-  margin-left: 30px;
-  width: 30%;
-  &__up {
-    height: 50vh;
-    text-align: center;
-    background-color: white;
-    padding: 30px 0;
-    border: solid 2px #e2dfdf;
-    border-radius: 3px;
-    &__title {
       font-size: 20px;
-      margin-bottom: 10px;
-      span {
-        border-bottom: solid 3px red;
-      }
+      margin: 0 30px;
     }
-    &__image {
-      height: 300px;
-      width: 200px;
-      object-fit: scale-down;
-      border: dashed 1px rgb(226, 234, 236);
-    }
-    &__list {
-      display: flex;
-      justify-content: center;
-      &__btn{
-        margin-left: 5px;
-        .circle__btn {
-          color: red;
-        }
-      }
+
+    #q_number_of_books_lt {
+      height: 40px;
+      width: 120px;
+      padding: 0 10px;
     }
   }
 
-  &__under {
-    background-color: white;
-    height: 500px;
-    margin-top: 10px;
-    padding: 40px;
-    text-align: center;
-    border: solid 2px #e2dfdf;
-    border-radius: 3px;
-    p {
+  &__btn {
+    margin: 40px auto 0;
+    width: 250px;
+    height: 40px;
+    .search__btn {
+      height: 100%;
+      width: 100%;
+      color: white;
+      font-weight: bold;
       font-size: 24px;
-      span {
-        border-bottom: solid 3px red;
-      }
+      background-color: rgb(147, 224, 147);
+      border: none;
+      border-radius: 20px;
+      cursor: pointer;
+      outline: none;
     }
-    &__list {
-      overflow: auto;
-      &__notice {
-        margin-bottom: 15px;
-        .notice__date {
-          text-align: left;
-          padding-left: 100px;
-        }
-      }
-      a:hover {
-        color: lightcoral;
-      }
+  }
+}
+
+
+//検索結果のCSS
+
+.search-result__box {
+  .search-result {
+    font-size: 24px;
+    color: rgb(147, 224, 147);
+    margin-bottom: 30px;
+  }
+
+  ul {
+    .search-result__count {
+      font-size: 20px;
+      margin-bottom: 20px;
     }
   }
 }

--- a/app/assets/stylesheets/modules/kaminari.scss
+++ b/app/assets/stylesheets/modules/kaminari.scss
@@ -1,5 +1,6 @@
 .pagination {
   display: flex;
+  padding-left: 50px;
   .page-item {
     margin-right: 10px;
     height: 40px;

--- a/app/controllers/comics_controller.rb
+++ b/app/controllers/comics_controller.rb
@@ -24,7 +24,9 @@ class ComicsController < ApplicationController
   def search
     @q = Comic.ransack(params[:q])
     @comics = @q.result(distinct: true)
+    @comics_count = @q.result(distinct: true)
     @comic = Comic.order(created_at: :desc).limit(5)
+    @comics = @comics.page(params[:page]).per(10)
   end
 
   private

--- a/app/views/authors/_main.html.haml
+++ b/app/views/authors/_main.html.haml
@@ -6,13 +6,15 @@
       %li.list__type.inactive__btn
         = link_to "検索", comics_path
   .display
-    %ul.display__list
-      - @comics.each do |comic|
-        %li.comic-box
-          = link_to author_path(comic.author.id), class: "comic-box__link" do
-            .comic-box__data
-              %p 
-                = comic.name
-              %p 
-                = comic.author.name
+    .comics__all-box
+      %p.comics__all 紹介作品一覧
+      %ul.display__list
+        - @comics.each do |comic|
+          %li.comic-box
+            = link_to author_path(comic.author.id), class: "comic-box__link" do
+              .comic-box__data
+                %p 
+                  = comic.name
+                %p 
+                  = comic.author.name
     = paginate @comics

--- a/app/views/comics/_top-one.html.haml
+++ b/app/views/comics/_top-one.html.haml
@@ -7,16 +7,23 @@
         %li.list__type.active__btn
           = link_to "検索", comics_path
     .display
-      = search_form_for @q, url: search_comics_path do |f|
-        = f.label :search
-        = f.search_field :name_or_author_name_cont, placeholder: "作品名、作者"
-        %br
-        = f.label :genre_id_eq, 'ジャンル'
-        = f.collection_select :genres_id_eq, @genres, :id, :genre, :include_blank => '指定なし'
-        %br
-        = f.label :number_of_books, "巻数"
-        = f.text_field :number_of_books_gteq, placeholder: "以上"
-        = f.label :number_of_books, "〜"
-        = f.text_field :number_of_books_lt, placeholder: "未満"
-        = f.submit "検索"
+      .search-box
+        %p 探したい条件で検索することができます
+        = search_form_for @q, url: search_comics_path do |f|
+          .search-box__word
+            = f.label :search, '作品名、作者名から探せます'
+            %br
+            = f.search_field :name_or_author_name_cont, placeholder: "(例)アライブ"
+          .search-box__genre
+            = f.label :genre_id_eq, 'ジャンル'
+            %br
+            = f.collection_select :genres_id_eq, @genres, :id, :genre, :include_blank => '指定なし'
+          .search-box__number-of-books
+            = f.label :number_of_books, "巻数"
+            %br
+            = f.text_field :number_of_books_gteq, placeholder: "以上"
+            = f.label :number_of_books, "〜", class: "wavy-line"
+            = f.text_field :number_of_books_lt, placeholder: "未満"
+          .search-box__btn
+            = f.submit "検  索", class: "search__btn"
   = render "authors/side"

--- a/app/views/comics/_top-two.html.haml
+++ b/app/views/comics/_top-two.html.haml
@@ -7,17 +7,22 @@
         %li.list__type.active__btn
           = link_to "検索", comics_path
     .display
-      - if @comics.present?
-        %ul.display__list
-          - @comics.each do |comic|
-            %li.comic-box
-              = link_to author_path(comic.author.id), class: "comic-box__link" do
-                .comic-box__data
-                  %p 
-                    = comic.name
-                  %p 
-                    = comic.author.name
-          = "#{@comics.count}件表示"
-      - else
-        %p 条件に一致する作品はありません
+      .search-result__box
+        %p.search-result 検索結果
+        - if @comics.present?
+          %ul.display__list
+            %p.search-result__count
+              = "#{@comics_count.count}件表示"
+            - @comics.each do |comic|
+              %li.comic-box
+                = link_to author_path(comic.author.id), class: "comic-box__link" do
+                  .comic-box__data
+                    %p 
+                      = comic.name
+                    %p 
+                      = comic.author.name
+            = "#{@comics.count}件表示"
+        - else
+          %p 条件に一致する作品はありません
+        = paginate @comics
   = render "authors/side"

--- a/app/views/comics/_top-two.html.haml
+++ b/app/views/comics/_top-two.html.haml
@@ -6,23 +6,32 @@
           = link_to "一覧", root_path
         %li.list__type.active__btn
           = link_to "検索", comics_path
-    .display
+    .display__search
       .search-result__box
         %p.search-result 検索結果
         - if @comics.present?
           %ul.display__list
             %p.search-result__count
-              = "#{@comics_count.count}件表示"
-            - @comics.each do |comic|
-              %li.comic-box
-                = link_to author_path(comic.author.id), class: "comic-box__link" do
-                  .comic-box__data
-                    %p 
-                      = comic.name
-                    %p 
-                      = comic.author.name
-            = "#{@comics.count}件表示"
+              = "#{@comics_count.count}件見つかりました"
+            .comics-box__list
+              - @comics.each do |comic|
+                %li.comic-box__result
+                  .up-left
+                  .under-right
+                  = link_to author_path(comic.author.id), class: "comic-box__link" do
+                    .comic-box__result__data
+                      %p.comic__result__image
+                        = image_tag comic.image.url
+                      .comic__result__name__list
+                        %p.comic__result__name
+                          = comic.name
+                        %p.comic__result__author-name
+                          = comic.author.name
+                    .comic-box__result__summary
+                      = comic.summary
+            %p.displayed__results
+              = "#{@comics_count.count}件中、#{@comics.count}件表示しています"
         - else
-          %p 条件に一致する作品はありません
+          %p.no__search-result 条件に一致する作品はありません
         = paginate @comics
   = render "authors/side"


### PR DESCRIPTION
# WHAT
 - 検索画面と検索結果の画面のCSSを書いた
 - 検索結果は10件ごとでページネーションで分割

 - 検索画面↓↓
![localhost_3000_comics](https://user-images.githubusercontent.com/69382240/97149501-2f4a1800-17b0-11eb-90dc-2a2eba76c354.png)

 - 検索結果（フル画面だと文字ずれ起きてない、原因究明必要）↓↓
![localhost_3000_comics_search_q%5Bname_or_author_name_cont%5D= q%5Bgenres_id_eq%5D= q%5Bnumber_of_books_gteq%5D= q%5Bnumber_of_books_lt%5D= commit=%E6%A4%9C++%E7%B4%A2](https://user-images.githubusercontent.com/69382240/97149544-3e30ca80-17b0-11eb-990e-67de81128696.png)


# WHY
 - 見た目の整頓は利便性のためにも必須のため