### PR TITLE
作品投稿/編集画面のCSS

### DIFF
--- a/app/assets/stylesheets/modules/authors.scss
+++ b/app/assets/stylesheets/modules/authors.scss
@@ -118,6 +118,7 @@
     height: calc(100% - 65px);
     padding: 40px 100px;
     .comics__all-box {
+      padding: 0 50px;
       .comics__all {
         font-size: 24px;
         color: rgb(147, 224, 147);
@@ -373,6 +374,160 @@
             border-radius: 30px;
             text-align: center;
           }
+        }
+      }
+    }
+  }
+}
+
+
+// 作品投稿のCSS（authors/new）
+.wrapper__comic {
+  display: block;
+  background-color: #f5f5f5;
+  height: auto;
+  padding: 30px 0;
+
+  // アプリ名のヘッダーCSS
+  .header__comic {
+    text-align: center;
+    .app-title__box {
+      font-size: 30px;
+      font-weight: bold;
+      text-align: center;
+      a {
+        padding: 20px;
+        background-color: #71dd9e;
+        border-radius: 50px;
+        color: white;
+        text-decoration: none;
+      }
+    }
+  }
+
+  .main__comic-box {
+    padding: 40px 0;
+    &__center {
+      width: 700px;
+      margin: 0 auto;
+      padding: 40px 0;
+      background-color: white;
+    }
+    h2 {
+      color: #93e093;
+      font-size: 24px;
+      width: 600px;
+      margin: 0 auto 20px;
+      text-align: center;
+    }
+
+    .field_all {
+      width: 600px;
+      margin: 0 auto;
+      .field {
+        margin-bottom: 20px;
+        span {
+          font-size: 13px;
+        }
+        .form_default {
+          width: 400px;
+          height: 40px;
+          padding: 15px;
+          outline: none;
+        }
+        .form_default:focus {
+          border: solid 1px #c7e9d5;
+          box-shadow: inset 0 0 5px #71dd9e;
+        }
+        .form_number {
+          width: 160px;
+          height: 40px;
+          padding: 15px;
+          outline: none;
+        }
+        //巻数フォームのスピンbtn消す
+        .form_number::-webkit-inner-spin-button,
+        .form_number::-webkit-outer-spin-button {
+            -webkit-appearance: none;
+            margin: 0;
+            -moz-appearance:textfield;
+        }
+        .form_number:focus {
+          border: solid 1px #c7e9d5;
+          box-shadow: inset 0 0 5px #71dd9e;
+        }
+        .form_textarea {
+          width: 580px;
+          height: 160px;
+          padding: 15px;
+          outline: none;
+          resize: none;
+        }
+        .form_textarea:focus {
+          border: solid 1px #c7e9d5;
+          box-shadow: inset 0 0 5px #71dd9e;
+        }
+        .form_image {
+          display: none;
+        }
+        .preview {
+          margin-top: 20px;
+          .previews__field {
+            position: relative;
+            img {
+              width: 200px;
+              height: 200px;
+              object-fit: scale-down;
+              border: dotted 1px lightgray;
+            }
+            .edit_btn-box {
+              position: absolute;
+              top: 30px;
+              left: 250px;
+              background-color: #f5f5f5;
+              border-radius: 10px;
+              padding: 10px 28px;
+              span {
+                cursor: pointer;
+                font-size: 18px;
+              }
+            }
+            .edit_btn-box:hover {
+              border: solid 1px #c7e9d5;
+              box-shadow: inset 0 0 5px #71dd9e;
+            }
+          }
+        }
+        .icon {
+          height: 70px;
+          width: 200px;
+          color: #c9f0bf;
+          font-size: 40px;
+          text-align: center;
+          background-color: rgb(245, 245, 245);
+          border: solid 1px black;
+          border-radius: 5px;
+          padding: 12px;
+          cursor: pointer;
+        }
+        .icon:hover {
+          border: solid 1px #c7e9d5;
+          box-shadow: inset 0 0 5px #71dd9e;
+          color: #9ae4b9;
+        }
+      }
+      .actions {
+        padding-top: 10px;
+        width: 320px;
+        margin: 0 auto;
+        .form_submit {
+          width: 320px;
+          height: 40px;
+          line-height: 40px;
+          background-color: #c7ecc7;
+          border: none;
+          cursor: pointer;
+          outline: none;
         }
       }
     }

--- a/app/assets/stylesheets/modules/authors.scss
+++ b/app/assets/stylesheets/modules/authors.scss
@@ -354,10 +354,16 @@
           border-radius: 30px;
           background-color: blanchedalmond;
         }
+        &__root:hover {
+          opacity: 0.6;
+        }
         &__edit-delete {
           margin-top: 50px;
           display: flex;
           justify-content: space-around;
+          a:hover {
+            opacity: 0.6;
+          }
           .show__edit-btn {
             background-color: lightblue;
             height: 30px;
@@ -379,6 +385,7 @@
     }
   }
 }
+
 
 
 // 作品投稿のCSS（authors/new）
@@ -412,6 +419,25 @@
       margin: 0 auto;
       padding: 40px 0;
       background-color: white;
+
+      .comic__delete__field {
+        margin: 30px auto 0;
+        width: 320px;
+        text-align: center;
+        background-color: #caccca;
+        cursor: pointer;
+        .comic__delete__btn {
+          width: 320px;
+          height: 40px;
+          line-height: 40px;
+          border: none;
+          text-decoration: none;
+          color: black;
+        }
+      }
+      .comic__delete__field:hover {
+        opacity: 0.6;
+      }
     }
     h2 {
       color: #93e093;
@@ -456,14 +482,25 @@
           border: solid 1px #c7e9d5;
           box-shadow: inset 0 0 5px #71dd9e;
         }
-        .form_textarea {
+        .form_summary {
           width: 580px;
-          height: 160px;
+          height: 200px;
           padding: 15px;
           outline: none;
           resize: none;
         }
-        .form_textarea:focus {
+        .form_review {
+          width: 580px;
+          height: 130px;
+          padding: 15px;
+          outline: none;
+          resize: none;
+        }
+        .form_summary:focus {
+          border: solid 1px #c7e9d5;
+          box-shadow: inset 0 0 5px #71dd9e;
+        }
+        .form_review:focus {
           border: solid 1px #c7e9d5;
           box-shadow: inset 0 0 5px #71dd9e;
         }
@@ -529,6 +566,9 @@
           cursor: pointer;
           outline: none;
         }
+      }
+      .actions:hover {
+        opacity: 0.6;
       }
     }
   }

--- a/app/assets/stylesheets/modules/users.scss
+++ b/app/assets/stylesheets/modules/users.scss
@@ -74,6 +74,9 @@
             outline: none;
           }
         }
+        .actions:hover {
+          opacity: 0.6;
+        }
       }
 
       //垢ある方はこちらへなどのbtn
@@ -90,7 +93,7 @@
         }
       }
 
-      .user__delete__fieid {
+      .user__delete__field {
         margin: 30px auto 0;
         width: 320px;
         .user__delete__btn {
@@ -102,6 +105,9 @@
           border: none;
           cursor: pointer;
         }
+      }
+      .user__delete__field:hover {
+        opacity: 0.6;
       }
     }
   }

--- a/app/assets/stylesheets/modules/users.scss
+++ b/app/assets/stylesheets/modules/users.scss
@@ -71,6 +71,7 @@
             background-color: #c7ecc7;
             border: none;
             cursor: pointer;
+            outline: none;
           }
         }
       }

--- a/app/javascript/authors.js
+++ b/app/javascript/authors.js
@@ -1,0 +1,39 @@
+$(document).on('turbolinks:load', ()=> {
+
+  function buildImg(url) {
+    const html = `<div class="previews__field">
+                    <img data-index="0" src="${url}" width="100px" height="100px">
+                    <div class="edit_btn-box">
+                      <span class="edit">画像を変更する</span>
+                    </div>
+                  </div>`;
+    return html;
+  }
+
+  $('.field').on('change', '.form_image', function(e) {
+    const file = e.target.files[0];
+    const blobUrl = window.URL.createObjectURL(file);
+
+
+    if (img = $(`img[data-index="0"]`)[0]) {
+      img.setAttribute('src', blobUrl);
+    } else {
+
+
+      $('.preview').append(buildImg(blobUrl));
+
+      $(`.fa-images`).hide();
+
+
+    }
+  });
+
+  $('.field').on('click', '.edit', function() {
+    $(`input[id="author_comics_attributes_0_image"]`).on('click', function(e){
+      e.stopPropagation();
+    });
+
+    $(`input[id="author_comics_attributes_0_image"]`).trigger('click');
+
+  });
+});

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -8,6 +8,7 @@ require("turbolinks").start()
 require("@rails/activestorage").start()
 require("channels")
 require('jquery')
+require('authors')
 
 
 // Uncomment to copy all static images under ../images to the output folder and reference

--- a/app/views/authors/edit.html.haml
+++ b/app/views/authors/edit.html.haml
@@ -1,25 +1,57 @@
-%h1 編集画面
-.manga
-  = form_with model: @author, html: {class: "Form"}, local: true do |a|
-    = a.text_field :name, placeholder: "作者"
-    %br
-    = a.fields_for :comics do |c|
-      = c.text_field :name, placeholder: "作品名"
-      %br
-      - if @comic.image?
-        = image_tag @comic.image.url
-      - else
-        = icon('fas', 'image', class: 'photo-icon')
-      %br
-      = c.file_field :image, placeholder: "漫画の画像"
-      %br
-      = c.number_field :number_of_books, placeholder: "巻数"
-      %br
-      = c.text_area :summary, placeholder: "あらすじ" 
-      %br
-      = c.text_area :review, placeholder: "レビュー"
-      %br
-      = c.collection_check_boxes :genre_ids, Genre.all, :id, :genre
-      %br
-    = a.submit "保存"
-  = link_to "削除", author_path(@author.id), method: :delete
+.wrapper__comic
+
+  .header__comic
+    %p.app-title__box
+      = link_to "Manga-App", root_path, class: "app-title"
+
+  .main__comic-box
+    %section.main__comic-box__center
+      %h2 作品情報編集
+      = form_with model: @author, html: {class: "Form"}, local: true do |a|
+        .field_all
+          .field
+            = a.label :name, "作者名"
+            %span （作者が2名以上いる場合は続けてご入力ください）
+            %br
+            = a.text_field :name, class: "form_default", required: true, placeholder: "例）河島正 × あだちとか"
+            %br
+          = a.fields_for :comics do |c|
+            .field
+              = c.label :name, "作品名"
+              %br
+              = c.text_field :name, class: "form_default", required: true, placeholder: "例）アライブ 最終進化的少年"
+              %br
+            .field
+              = c.label :number_of_books, "巻数"
+              %br
+              = c.number_field :number_of_books, class: "form_number", required: true
+              %br
+            .field
+              = c.label :number_of_books, "ジャンル"
+              %span （複数選択可）
+              %br
+              = c.collection_check_boxes :genre_ids, Genre.all, :id, :genre
+              %br
+            .field
+              = c.label :number_of_books, "画像"
+              %span （表紙など作品がわかる画像を選択ください）
+              = c.file_field :image, class: "form_image", required: true
+              %br
+              .preview
+                .previews__field
+                  = image_tag @comic.image.url, data: { index: 0 }
+                  .edit_btn-box
+                    %span.edit 画像を変更する
+            .field
+              = c.label :summary, "あらすじ"
+              %br
+              = c.text_area :summary, class: "form_summary", required: true
+            .field
+              = c.label :review, "レビュー"
+              %br
+              = c.text_area :review, class: "form_review", required: true, placeholder: "3つ程おすすめポイントをお書きください"
+          .actions
+            = a.submit "更新する", class: "form_submit"
+      .comic__delete__field
+        = link_to  author_path(@author.id), method: :delete, class: "comic__delete__btn" do
+          .comic__delete__box 削除する

--- a/app/views/authors/new.html.haml
+++ b/app/views/authors/new.html.haml
@@ -1,19 +1,52 @@
-%h1 新規投稿画面
-.manga
-  = form_with model: @author, html: {class: "Form"}, local: true do |a|
-    = a.text_field :name, placeholder: "作者"
-    %br
-    = a.fields_for :comics do |c|
-      = c.text_field :name, placeholder: "作品名"
-      %br
-      = c.file_field :image, placeholder: "漫画の画像"
-      %br
-      = c.number_field :number_of_books, placeholder: "巻数"
-      %br
-      = c.text_area :summary, placeholder: "あらすじ" 
-      %br
-      = c.text_area :review, placeholder: "レビュー"
-      %br
-      = c.collection_check_boxes :genre_ids, Genre.all, :id, :genre
-      %br
-    = a.submit "保存"
+.wrapper__comic
+
+  .header__comic
+    %p.app-title__box
+      = link_to "Manga-App", root_path, class: "app-title"
+
+  .main__comic-box
+    %section.main__comic-box__center
+      %h2 作品投稿
+      = form_with model: @author, html: {class: "Form"}, local: true do |a|
+        .field_all
+          .field
+            = a.label :name, "作者名"
+            %span （作者が2名以上いる場合は続けてご入力ください）
+            %br
+            = a.text_field :name, class: "form_default", required: true, placeholder: "例）河島正 × あだちとか"
+            %br
+          = a.fields_for :comics do |c|
+            .field
+              = c.label :name, "作品名"
+              %br
+              = c.text_field :name, class: "form_default", required: true, placeholder: "例）アライブ 最終進化的少年"
+              %br
+            .field
+              = c.label :number_of_books, "巻数"
+              %br
+              = c.number_field :number_of_books, class: "form_number", required: true
+              %br
+            .field
+              = c.label :number_of_books, "ジャンル"
+              %span （複数選択可）
+              %br
+              = c.collection_check_boxes :genre_ids, Genre.all, :id, :genre
+              %br
+            .field
+              = c.label :number_of_books, "画像"
+              %span （表紙など作品がわかる画像を選択ください）
+              = c.file_field :image, class: "form_image", required: true
+              %br
+              .preview
+              %label{for: "author_comics_attributes_0_image", class: 'label'}
+                %i.far.fa-images.icon
+            .field
+              = c.label :summary, "あらすじ"
+              %br
+              = c.text_area :summary, class: "form_textarea", required: true
+            .field
+              = c.label :review, "レビュー"
+              %br
+              = c.text_area :review, class: "form_textarea", required: true, placeholder: "3つ程おすすめポイントをお書きください"
+          .actions
+            = a.submit "投稿する", class: "form_submit"

--- a/app/views/authors/new.html.haml
+++ b/app/views/authors/new.html.haml
@@ -43,10 +43,10 @@
             .field
               = c.label :summary, "あらすじ"
               %br
-              = c.text_area :summary, class: "form_textarea", required: true
+              = c.text_area :summary, class: "form_summary", required: true
             .field
               = c.label :review, "レビュー"
               %br
-              = c.text_area :review, class: "form_textarea", required: true, placeholder: "3つ程おすすめポイントをお書きください"
+              = c.text_area :review, class: "form_review", required: true, placeholder: "3つ程おすすめポイントをお書きください"
           .actions
             = a.submit "投稿する", class: "form_submit"

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -36,7 +36,7 @@
             = f.password_field :current_password, autocomplete: "current-password", class: "form_default", required: true
           .actions
             = f.submit "変更する", class: "form_submit"
-      .user__delete__fieid
+      .user__delete__field
         #{button_to "アカウントを削除する", registration_path(resource_name), data: { confirm: "アカウントを削除しますか？" }, method: :delete, class: "user__delete__btn"}
 
 


### PR DESCRIPTION
# WHAT
 - 作品の新規投稿、編集画面のCSSを書いた
 - 画像は、選択するとプレビュー表示される

 - 新規投稿画面↓↓
![localhost_3000_authors_new](https://user-images.githubusercontent.com/69382240/97547175-d3ca9500-1a10-11eb-9139-babcbcd6976b.png)


 - 編集画面↓↓
![localhost_3000_authors_new (1)](https://user-images.githubusercontent.com/69382240/97547127-c44b4c00-1a10-11eb-9d24-21f5bd364391.png)


# WHY
 - CSSの記述は必須のため
 - 見やすさ、利便性向上のため