### PR TITLE
ドロワーメニューの実装

### DIFF
--- a/app/assets/stylesheets/modules/authors.scss
+++ b/app/assets/stylesheets/modules/authors.scss
@@ -38,15 +38,6 @@
         cursor: pointer;
       }
     }
-    // .three_bars-icon {
-    //   position: absolute;
-    //   top: 10px;
-    //   left: -45px;
-    //   .three_bars {
-    //     font-size: 30px;
-    //     cursor: pointer;
-    //   }
-    // }
     .peke-none {
       display: none;
     }

--- a/app/assets/stylesheets/modules/authors.scss
+++ b/app/assets/stylesheets/modules/authors.scss
@@ -17,6 +17,93 @@
 // ヘッダーのCSS
 .header {
   height: auto;
+  #menu {
+    width: 310px;
+    height: 100vh;
+    border-left: solid 1px silver;
+    padding-top: 50px;
+    position: fixed;
+    top: 0;
+    right: 0;
+    z-index: 10;
+    transform: translateX(300px); /* right0から250px移動した位置 */
+    transition: all .5s; /* 移動する速さ */
+    .peke {
+      position: absolute;
+      top: 0;
+      left: -45px;
+      .peke_mark {      //バッテンアイコン
+        color: rgb(82, 85, 82);
+        font-size: 50px;
+        cursor: pointer;
+      }
+    }
+    // .three_bars-icon {
+    //   position: absolute;
+    //   top: 10px;
+    //   left: -45px;
+    //   .three_bars {
+    //     font-size: 30px;
+    //     cursor: pointer;
+    //   }
+    // }
+    .peke-none {
+      display: none;
+    }
+    ul {
+      border-top: solid 1px silver;
+      .menu_list {
+        border-bottom: solid 1px silver;
+        padding: 15px;
+        position: relative;
+        a:hover {
+          color: lightcoral;
+        }
+        .maru_btn {           // 画面右の丸btn
+          position: absolute;
+          width: 10px;
+          height: 10px;
+          border-radius: 50%;
+          background-color: #b6bdb2;
+          border: solid 1px rgb(190, 184, 184);
+          left: -5px;
+          top: 50%;
+          transform: translateY(-50%);
+          -webkit-transform: translateY(-50%);
+          -ms-transform: translateY(-50%);
+        }
+        .maru_btn.open {
+          border: solid 1px black;
+          background-color: black;
+          width: 15px;
+          height: 3px;
+        }
+      }
+    }
+  }
+  #menu.open {
+    transform: translateX(0); /* right0まで-250px移動 */
+    background-color: #e0ecd9;
+    border: none;
+  }
+  .menu-background {
+    position: fixed;
+    top: 0;
+    left: 0;
+    content: "";
+    display: block;
+    width: 0;
+    height: 0;
+    background-color: rgba(0, 0, 0, 0.5);
+    z-index: 2;
+    opacity: 0; /* 透明度を0にすることで隠す */
+    transition: opacity 0.5s; /* 透明度の0→1になる速度 */
+  }
+  .menu-background.open {
+    width: 100%;
+    height: 100%;
+    opacity: 1; /* メニューが表示されているときには背景が表示 */
+  }
   &__up {
     display: flex;
     align-items: flex-end;
@@ -50,6 +137,18 @@
         }
         .btn:hover {
           color: lightcoral;
+        }
+        .current__user__name {
+          line-height: 30px;
+          margin-right: 20px;
+        }
+        .current__user__name:hover {
+          color: lightcoral;
+          cursor: pointer;
+        }
+        .three_bars {
+          font-size: 28px;
+          cursor: pointer;
         }
       }
     }

--- a/app/javascript/drawer_menu.js
+++ b/app/javascript/drawer_menu.js
@@ -1,0 +1,32 @@
+$(window).on('load', ()=> {
+
+  // MENUボタンがクリックされたときの処理
+  $('#menu_btn').on('click', function(){
+    $('#menu').addClass('open'); // #menuに.openを追加
+    $('.menu-background').addClass('open'); // .menu-backgroundに.openを追加
+    $('.maru_btn').addClass('open'); //  .maru_btnにopenクラス追加してbtnの色を変更
+    $('.peke').removeClass('peke-none');  // .pekeにつけてるpeke-none(display隠してる)を消してアイコンを表示
+    
+  });
+
+  $('.peke').on('click', function(){
+    // .menu-backgroundに.openがあるかどうか
+    $('#menu').removeClass('open'); // #menuの.openを削除
+    $('.menu-background').removeClass('open'); // .menu-backgroundの.openを削除
+    $('.maru_btn').removeClass('open');
+    $('.peke').addClass('peke-none');
+  });
+
+  // メニューの背景がクリックされたときの処理
+  $('.menu-background').on('click', function(){
+    // .menu-backgroundに.openがあるかどうか
+    if($(this).hasClass('open')) {
+      // .openがあるときの処理
+      $(this).removeClass('open'); // .menu-backgroundの.openを削除
+      $('#menu').removeClass('open'); // #menuの.openを削除
+      $('.maru_btn').removeClass('open');
+      $('.peke').addClass('peke-none');
+    }
+  });
+
+});

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -10,7 +10,7 @@ require("channels")
 require('jquery')
 require('authors')
 require('slideshow')
-
+require('drawer_menu')
 
 // Uncomment to copy all static images under ../images to the output folder and reference
 // them with the image_pack_tag helper in views (e.g <%= image_pack_tag 'rails.png' %>)

--- a/app/views/authors/_header.html.haml
+++ b/app/views/authors/_header.html.haml
@@ -23,8 +23,6 @@
     %nav#menu
       .peke.peke-none
         = icon("fas", "times", class: "peke_mark")
-      -# .three_bars-icon#menu_btn
-      -#   = icon("fas", "bars", class: "three_bars")
       %ul
         %li.menu_list
           .maru_btn

--- a/app/views/authors/_header.html.haml
+++ b/app/views/authors/_header.html.haml
@@ -4,25 +4,48 @@
       %span 管理者のおすすめ漫画の紹介、備忘録なアプリとなっています。コメントもご自由にお書きください。
     .header__up__right
       %ul
-        - if user_signed_in? && current_user.admin?
-          %li
-            = link_to "ログアウト", destroy_user_session_path, method: :delete, class: "logout-btn btn"
-          %li
-            = link_to "マイページ遷移にしたい", edit_user_registration_path, class: "edit-btn btn"
-          %li
-            = link_to "投稿", new_author_path, class: "logout-btn btn"
-        - elsif user_signed_in?
-          %li
-            = link_to "ログアウト", destroy_user_session_path, method: :delete, class: "logout-btn btn"
-          %li
-            = link_to "マイページ遷移にしたい", edit_user_registration_path, class: "edit-btn btn"
+        - if user_signed_in?
+          %li.current__user__name
+            = current_user.name
+          %li#menu_btn.btn
+            = icon("fas", "bars", class: "three_bars")
         - else
           %li
             = link_to "ログイン", new_user_session_path, class: "login-btn btn"
           %li
             = link_to "新規登録", new_user_registration_path, class: "new-btn btn"
+        
 
   .header__under
     %p.app-title__box
       = link_to "Manga-App", root_path, class: "app-title"
+  - if user_signed_in?
+    %nav#menu
+      .peke.peke-none
+        = icon("fas", "times", class: "peke_mark")
+      -# .three_bars-icon#menu_btn
+      -#   = icon("fas", "bars", class: "three_bars")
+      %ul
+        %li.menu_list
+          .maru_btn
+          = link_to edit_user_registration_path, class: "edit-btn btn" do
+            %p アカウント編集
+        %li.menu_list
+          .maru_btn
+          = link_to "#" do
+            %p ブックマーク一覧
+        - if user_signed_in? && current_user.admin?
+          %li.menu_list
+            .maru_btn
+            = link_to new_author_path, class: "logout-btn btn" do
+              %p 作品投稿
+          %li.menu_list
+            .maru_btn
+            = link_to "#" do
+              %p 管理者画面
+        %li.menu_list
+          .maru_btn
+          = link_to destroy_user_session_path, method: :delete, class: "logout-btn btn" do
+            %p ログアウト
+    .menu-background
 


### PR DESCRIPTION
# WHAT
 - トップページのヘッダーの３本線クリックでドロワーメニュー出現
 - ヘッダーに表示していた投稿btnなどをドロワーメニューに移した
 - メニューはサインイン、ログアウトで表示/非表示
 - ドロワーメニューの内容は、管理者かどうかで表示するタグを調整

 - 画像（展開前↓↓
<img width="1440" alt="スクリーンショット 2020-10-30 22 22 45" src="https://user-images.githubusercontent.com/69382240/97709934-70b72c00-1afe-11eb-9734-978a737ed8ef.png">

 - 画像（展開後↓↓↓
<img width="1440" alt="スクリーンショット 2020-10-30 22 23 13" src="https://user-images.githubusercontent.com/69382240/97709983-8298cf00-1afe-11eb-808f-2082d5c3daa9.png">

# WHY
 - 見栄えをよくする、利便性向上のため
 - 実装してみたかった、自身の実力向上のため