### PR TITLE
スライドショー修正

### DIFF
--- a/app/assets/stylesheets/modules/authors.scss
+++ b/app/assets/stylesheets/modules/authors.scss
@@ -86,7 +86,7 @@
     width: 0;
     height: 0;
     background-color: rgba(0, 0, 0, 0.5);
-    z-index: 2;
+    z-index: 3;
     opacity: 0; /* 透明度を0にすることで隠す */
     transition: opacity 0.5s; /* 透明度の0→1になる速度 */
   }
@@ -265,6 +265,7 @@
     }
     .show {         // 画像の対象を表示コーーど
       opacity: 1;
+      z-index: 2;
     }
     &__title {
       font-size: 20px;

--- a/app/views/authors/_side.html.haml
+++ b/app/views/authors/_side.html.haml
@@ -3,7 +3,7 @@
     .side__up__title 
       %span 管理者のオススメ
     %ul.slide_show-box
-      %li.slide__image{data: { index: 0 }}
+      %li.slide__image.show{data: { index: 0 }}
         = link_to image_tag(@comic_one.image.url, class: "side__up__image", id: "slideshow_one"), comic_path(id: @comic_one)
       %li.slide__image.display_hide{data: { index: 1 }}
         = link_to image_tag(@comic_two.image.url, class: "side__up__image", id: "slideshow_two"), comic_path(id: @comic_two)


### PR DESCRIPTION
# WHAT
 - スライドショーで遷移先が固定されていたため、修正した
 - 画像は切り替わるがいつタイミングで押しても、5番目のリンクに遷移してしまう
 - 理由として、opacity: 0;で透明にしていたため、見た目は切り替わっても、実際クリックされてたのは5番目の要素だった（同じ位置に要素を重ねていたため起きた）（display: none;にはせずopacityにしているから）
 - 解決策、アクティブな要素にz-index2を当てて、一番前に持ってきた
 - 画像がz-index2にしたため、ドロワーメニュー表示した時の背景暗くする要素のz-indexを２→３に変更

# WHY
 - 挙動確認で発見したため