### PR TITLE
ジャンル追加と見た目修正

### DIFF
--- a/app/assets/stylesheets/modules/authors.scss
+++ b/app/assets/stylesheets/modules/authors.scss
@@ -457,6 +457,19 @@
           &__genre {
             font-size: 20px;
             margin-bottom: 20px;
+            display: flex;
+            .infoTitle {
+              min-width: 80px;
+            }
+            .blueColor {
+              min-width: 400px;
+              display: flex;
+              flex-wrap: wrap;
+              .genre_single {
+                min-width: 100px;
+                margin: 0 25px 5px 0;
+              }
+            }
           }
         }
       }

--- a/app/assets/stylesheets/modules/authors.scss
+++ b/app/assets/stylesheets/modules/authors.scss
@@ -688,6 +688,15 @@
         .form_image {
           display: none;
         }
+        // チェックボックスのデザイン
+        .checkboxes {
+          display: flex;
+          flex-wrap: wrap;
+          .box {
+            min-width: 170px;
+            margin-bottom: 5px;
+          }
+        }
         .preview {
           margin-top: 20px;
           .previews__field {

--- a/app/controllers/authors_controller.rb
+++ b/app/controllers/authors_controller.rb
@@ -5,11 +5,11 @@ class AuthorsController < ApplicationController
     @authors = Author.all
     @comics = Comic.all.page(params[:page]).per(15)
     @comic = Comic.order(created_at: :desc).limit(5)
-    @comic_one = Comic.find(3)
-    @comic_two = Comic.find(4)
-    @comic_three = Comic.find(5)
-    @comic_four = Comic.find(6)
-    @comic_five = Comic.find(7)
+    @comic_one = Comic.find(1)
+    @comic_two = Comic.find(2)
+    @comic_three = Comic.find(3)
+    @comic_four = Comic.find(4)
+    @comic_five = Comic.find(5)
   end
 
   def new

--- a/app/controllers/comics_controller.rb
+++ b/app/controllers/comics_controller.rb
@@ -6,11 +6,11 @@ class ComicsController < ApplicationController
     @genres = Genre.all
     @comics = @q.result(distinct: true)
     @comic = Comic.order(created_at: :desc).limit(5)
-    @comic_one = Comic.find(3)
-    @comic_two = Comic.find(4)
-    @comic_three = Comic.find(5)
-    @comic_four = Comic.find(6)
-    @comic_five = Comic.find(7)
+    @comic_one = Comic.find(1)
+    @comic_two = Comic.find(2)
+    @comic_three = Comic.find(3)
+    @comic_four = Comic.find(4)
+    @comic_five = Comic.find(5)
   end
 
   def new
@@ -37,11 +37,11 @@ class ComicsController < ApplicationController
     @comics_count = @q.result(distinct: true)
     @comic = Comic.order(created_at: :desc).limit(5)
     @comics = @comics.page(params[:page]).per(10)
-    @comic_one = Comic.find(3)
-    @comic_two = Comic.find(4)
-    @comic_three = Comic.find(5)
-    @comic_four = Comic.find(6)
-    @comic_five = Comic.find(7)
+    @comic_one = Comic.find(1)
+    @comic_two = Comic.find(2)
+    @comic_three = Comic.find(3)
+    @comic_four = Comic.find(4)
+    @comic_five = Comic.find(5)
   end
 
   private

--- a/app/controllers/comics_controller.rb
+++ b/app/controllers/comics_controller.rb
@@ -29,6 +29,7 @@ class ComicsController < ApplicationController
   def show
     @author = Author.find(params[:id])
     @comic = Comic.find(params[:id])
+    @comic_genre = @comic.genres.pluck(:genre)
   end
 
   def search

--- a/app/views/authors/_side.html.haml
+++ b/app/views/authors/_side.html.haml
@@ -3,16 +3,17 @@
     .side__up__title 
       %span 管理者のオススメ
     %ul.slide_show-box
-      %li.slide__image.show{data: { index: 0 }}
-        = link_to image_tag(@comic_one.image.url, class: "side__up__image", id: "slideshow_one"), comic_path(id: @comic_one)
-      %li.slide__image.display_hide{data: { index: 1 }}
-        = link_to image_tag(@comic_two.image.url, class: "side__up__image", id: "slideshow_two"), comic_path(id: @comic_two)
-      %li.slide__image.display_hide{data: { index: 2 }}
-        = link_to image_tag(@comic_three.image.url, class: "side__up__image", id: "slideshow_three"), comic_path(id: @comic_three)
-      %li.slide__image.display_hide{data: { index: 3 }}
-        = link_to image_tag(@comic_four.image.url, class: "side__up__image", id: "slideshow_four"), comic_path(id: @comic_four)
-      %li.slide__image.display_hide{data: { index: 4 }}
-        = link_to image_tag(@comic_five.image.url, class: "side__up__image", id: "slideshow_five"), comic_path(id: @comic_five)
+      - if @comic.present?      ##DBにデータがない場合は表示しない（これしないとエラー出る→→→この下もコメントアウトにしないとだめだった（DBある判定で下表示になるが、まだ１個しかなかったら結局エラー出てしまう
+        %li.slide__image.show{data: { index: 0 }}
+          = link_to image_tag(@comic_one.image.url, class: "side__up__image", id: "slideshow_one"), comic_path(id: @comic_one)
+        %li.slide__image.display_hide{data: { index: 1 }}
+          = link_to image_tag(@comic_two.image.url, class: "side__up__image", id: "slideshow_two"), comic_path(id: @comic_two)
+        %li.slide__image.display_hide{data: { index: 2 }}
+          = link_to image_tag(@comic_three.image.url, class: "side__up__image", id: "slideshow_three"), comic_path(id: @comic_three)
+        %li.slide__image.display_hide{data: { index: 3 }}
+          = link_to image_tag(@comic_four.image.url, class: "side__up__image", id: "slideshow_four"), comic_path(id: @comic_four)
+        %li.slide__image.display_hide{data: { index: 4 }}
+          = link_to image_tag(@comic_five.image.url, class: "side__up__image", id: "slideshow_five"), comic_path(id: @comic_five)
     %ul.side__up__list
       %li.side__up__list__btn
         .circle__btn-box{data: { index: 0 }}

--- a/app/views/authors/edit.html.haml
+++ b/app/views/authors/edit.html.haml
@@ -30,12 +30,16 @@
               = c.label :number_of_books, "ジャンル"
               %span （複数選択可）
               %br
-              = c.collection_check_boxes :genre_ids, Genre.all, :id, :genre
+              .checkboxes
+                = c.collection_check_boxes :genre_ids, Genre.all, :id, :genre do |d|
+                  .box
+                    = d.check_box
+                    = d.label { d.text }
               %br
             .field
               = c.label :number_of_books, "画像"
               %span （表紙など作品がわかる画像を選択ください）
-              = c.file_field :image, class: "form_image", required: true
+              = c.file_field :image, class: "form_image"
               %br
               .preview
                 .previews__field

--- a/app/views/authors/new.html.haml
+++ b/app/views/authors/new.html.haml
@@ -30,7 +30,11 @@
               = c.label :number_of_books, "ジャンル"
               %span （複数選択可）
               %br
-              = c.collection_check_boxes :genre_ids, Genre.all, :id, :genre
+              .checkboxes
+                = c.collection_check_boxes :genre_ids, Genre.all, :id, :genre do |d|
+                  .box
+                    = d.check_box
+                    = d.label { d.text }
               %br
             .field
               = c.label :number_of_books, "画像"

--- a/app/views/comics/show.html.haml
+++ b/app/views/comics/show.html.haml
@@ -37,9 +37,11 @@
               %span.redColor （完結作品）
               -# %span 未完結作品  ココif文で場合分けした（activehash)
             .show__info__genre
-              %span.infoTitle ジャンル：
-              %span.blueColor
-                = @comic.genres.pluck(:genre).join("　")
+              .infoTitle ジャンル：
+              .blueColor
+                - @comic_genre.each do |genre|
+                  .genre_single
+                    = genre
         .show__summary
           %span あらすじ
           %div

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -11,3 +11,31 @@ User.create!(name:  "管理者",
              password:  "12345678",
              password_confirmation: "12345678",
              admin: true)
+
+Genre.create!(
+  [
+    { genre: '女性漫画' },
+    { genre: '少女漫画' },
+    {genre: '青年漫画' },
+    {genre: '少年漫画' },
+    {genre: 'TL漫画' },
+    {genre: 'BL漫画' },
+    {genre: 'オトナ漫画' },
+    {genre: '恋愛' },
+    {genre: 'ヒューマンドラマ' },
+    {genre: 'ギャグ・コメディー' },
+    {genre: '職業・ビジネス' },
+    {genre: 'サスペンス・ミステリー' },
+    {genre: '歴史・時代劇' },
+    {genre: 'スポーツ' },
+    {genre: 'アクション・アドベンチャー' },
+    {genre: 'ホラー' },
+    {genre: 'SF・ファンタジー' },
+    {genre: 'グルメ' },
+    {genre: '医療・病院系' },
+    {genre: 'メカ' },
+    {genre: '日常系' },
+    {genre: 'バトル' },
+    {genre: 'ラノベ原作' }
+  ]
+)


### PR DESCRIPTION
# WHAT
 - 作品のジャンルを追加した
 - ウェブにあるサイトを参考に追加と足らないと思ったジャンルを自身で追加
 - ジャンルはseedファイルに記述
 - db:seedするために一度resetした
 - 作品投稿、編集画面で、チェックボックスが左つめになっていたので、バランスのいい見た目に修正
 - 作品詳細画面のジャンル表示も、見た目修正

 - 詳細↓↓
<img width="1440" alt="スクリーンショット 2020-11-06 10 24 29" src="https://user-images.githubusercontent.com/69382240/98314881-4394dd00-201a-11eb-9849-8199f7c53ab7.png">

 - 編集（投稿も同様）↓↓
<img width="1440" alt="スクリーンショット 2020-11-06 10 24 43" src="https://user-images.githubusercontent.com/69382240/98314904-4c85ae80-201a-11eb-9a1c-a2dec635bff8.png">

# WHY
 - どういった作品なのかジャンルがある方が利用者に伝わるため
 - 自身の実力アップのため
 - 必須機能のため