### PR TITLE
activehashを使って、おすすめ作品idを追加

### DIFF
--- a/app/controllers/authors_controller.rb
+++ b/app/controllers/authors_controller.rb
@@ -85,22 +85,22 @@ class AuthorsController < ApplicationController
   private
 
   def author_params
-    params.require(:author).permit(:name, comics_attributes: [:name, :image, :number_of_books, :summary, :review, :booknumber_id, genre_ids: []])
+    params.require(:author).permit(:name, comics_attributes: [:name, :image, :number_of_books, :summary, :review, :booknumber_id, :recommend_id, genre_ids: []])
   end
 
   def update_author_params
-    params.require(:author).permit(:name, comics_attributes: [:name, :image, :number_of_books, :summary, :review, :booknumber_id, {genre_ids: []}, :_destroy, :id])
+    params.require(:author).permit(:name, comics_attributes: [:name, :image, :number_of_books, :summary, :review, :booknumber_id, :recommend_id, {genre_ids: []}, :_destroy, :id])
   end
 
   def comic_params
-    params.require(:author).require(:comics_attributes).require("0").permit(:name, :image, :number_of_books, :summary, :review, :booknumber_id, genre_ids: []).merge(author_id: @author.id)
+    params.require(:author).require(:comics_attributes).require("0").permit(:name, :image, :number_of_books, :summary, :review, :booknumber_id, :recommend_id, genre_ids: []).merge(author_id: @author.id)
   end
 
   def update_author_comic_params     ##元の作者変更しなかった場合こっち（変更前の作者idをmarge）
-    params.require(:author).require(:comic).permit(:name, :image, :number_of_books, :summary, :review, :booknumber_id, genre_ids: []).merge(author_id: @author.id)
+    params.require(:author).require(:comic).permit(:name, :image, :number_of_books, :summary, :review, :booknumber_id, :recommend_id, genre_ids: []).merge(author_id: @author.id)
   end
 
   def update_author_db_find_comic_params     ##元の作者から変更した場合こっち（変更後の作者idをmarge）
-    params.require(:author).require(:comic).permit(:name, :image, :number_of_books, :summary, :review, :booknumber_id, genre_ids: []).merge(author_id: @author_db_find.id)
+    params.require(:author).require(:comic).permit(:name, :image, :number_of_books, :summary, :review, :booknumber_id, :recommend_id, genre_ids: []).merge(author_id: @author_db_find.id)
   end
 end

--- a/app/models/comic.rb
+++ b/app/models/comic.rb
@@ -1,6 +1,7 @@
 class Comic < ApplicationRecord
   extend ActiveHash::Associations::ActiveRecordExtensions
   belongs_to_active_hash :booknumber
+  belongs_to_active_hash :recommend
   
   belongs_to :author
   has_many :comic_genres, dependent: :destroy

--- a/app/models/recommend.rb
+++ b/app/models/recommend.rb
@@ -1,0 +1,6 @@
+class Recommend < ActiveHash::Base
+  self.data = [
+    {id: 1, name: 'おすすめにする'}, 
+    {id: 2, name: 'おすすめにしない'}
+  ]
+end

--- a/app/views/authors/edit.html.haml
+++ b/app/views/authors/edit.html.haml
@@ -33,6 +33,11 @@
               = c.collection_select :booknumber_id, Booknumber.all, :id, :name, {include_blank: "選択してください"}, required: true, class: "form_booknumber"
               %br
             .field
+              = c.label :number_of_books, "管理者のおすすめに入れる"
+              %br
+              = c.collection_select :recommend_id, Recommend.all, :id, :name, {include_blank: "選択してください"}, required: true, class: "form_booknumber"
+              %br
+            .field
               = c.label :number_of_books, "ジャンル"
               %span （複数選択可）
               %br

--- a/app/views/authors/new.html.haml
+++ b/app/views/authors/new.html.haml
@@ -32,6 +32,11 @@
               = c.collection_select :booknumber_id, Booknumber.all, :id, :name, {include_blank: "選択してください"}, required: true, class: "form_booknumber"
               %br
             .field
+              = c.label :number_of_books, "管理者のおすすめに入れる"
+              %br
+              = c.collection_select :recommend_id, Recommend.all, :id, :name, {include_blank: "選択してください"}, required: true, class: "form_booknumber"
+              %br
+            .field
               = c.label :number_of_books, "ジャンル"
               %span （複数選択可）
               %br

--- a/db/migrate/20201109021553_add_colmun_to_comics_to_recommend.rb
+++ b/db/migrate/20201109021553_add_colmun_to_comics_to_recommend.rb
@@ -1,0 +1,5 @@
+class AddColmunToComicsToRecommend < ActiveRecord::Migration[6.0]
+  def change
+    add_column :comics, :recommend_id, :integer, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_06_021442) do
+ActiveRecord::Schema.define(version: 2020_11_09_021553) do
 
   create_table "authors", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -46,6 +46,7 @@ ActiveRecord::Schema.define(version: 2020_11_06_021442) do
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "author_id"
     t.integer "booknumber_id", null: false
+    t.integer "recommend_id", null: false
     t.index ["author_id"], name: "index_comics_on_author_id"
   end
 


### PR DESCRIPTION
# WHAT
 - 作品に対して、管理者のおすすめにするかどうかを追加
 - 管理者のおすすめにするか/しないかをactivehashで追加
 - モデル名は、recommendモデル、comicsテーブルのカラムにrecommend_idを追加

# WHY
 - 全登録作品の中から、特におすすめする作品のみを表示する画面を作成したかった
 - 少し懐かしい、コアな作品をユーザーの目に止まりやすくしたかった