### PR TITLE
おすすめ作品一覧のビュー作成

### DIFF
--- a/app/assets/stylesheets/modules/authors.scss
+++ b/app/assets/stylesheets/modules/authors.scss
@@ -183,11 +183,14 @@
     padding-top: 4px;
     &__list {
       display: flex;
+      padding-left: 20px;
       .list__type {
         background-color: #e2dfdf;
-        margin-left: 50px;
         padding: 10px;
         border-radius: 10px 10px 0 0;
+        min-width: 100px;
+        text-align: center;
+        margin-left: 5px;
         a {
           font-size: 20px;
           font-weight: bold;

--- a/app/controllers/comics_controller.rb
+++ b/app/controllers/comics_controller.rb
@@ -45,6 +45,18 @@ class ComicsController < ApplicationController
     @comic_five = Comic.find(5)
   end
 
+  def recommend
+    @authors = Author.all
+    # @comics = Comic.all.page(params[:page]).per(10)   ##ページネーション
+    @comic = Comic.order(created_at: :desc).limit(5)    ##サイドバーの登録最新から5件取得
+    @comics_recommend = Comic.where(recommend_id: 1).page(params[:page]).per(10)    ##おすすめ作品を取得、ページネーションを10作品ごと
+    @comic_one = Comic.find(1)
+    @comic_two = Comic.find(7)
+    @comic_three = Comic.find(3)
+    @comic_four = Comic.find(4)
+    @comic_five = Comic.find(5)
+  end
+
   private
 
   def comic_params

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -12,7 +12,7 @@ class Ability
         can :access, :rails_admin
         can :manage, :all
       else
-        can [:index, :show, :search], [Author, Comic]
+        can [:index, :show, :search, :recommend], [Author, Comic]   ##管理者以外に許可するアクション
       end
     #
     # The first argument to `can` is the action you are giving the user

--- a/app/views/authors/_main.html.haml
+++ b/app/views/authors/_main.html.haml
@@ -1,8 +1,10 @@
 .main
   .select
     %ul.select__list
+      %li.list__type.inactive__btn
+        = link_to "おすすめ", recommend_comics_path
       %li.list__type.active__btn
-        = link_to "一覧", root_path
+        = link_to "一覧", authors_path
       %li.list__type.inactive__btn
         = link_to "検索", comics_path
   .display

--- a/app/views/authors/_side.html.haml
+++ b/app/views/authors/_side.html.haml
@@ -1,7 +1,7 @@
 .side 
   .side__up
     .side__up__title 
-      %span 管理者のオススメ
+      %span 今月のオススメ
     %ul.slide_show-box
       - if @comic.present?      ##DBにデータがない場合は表示しない（これしないとエラー出る→→→この下もコメントアウトにしないとだめだった（DBある判定で下表示になるが、まだ１個しかなかったら結局エラー出てしまう
         %li.slide__image.show{data: { index: 0 }}

--- a/app/views/comics/_top-one.html.haml
+++ b/app/views/comics/_top-one.html.haml
@@ -3,7 +3,9 @@
     .select
       %ul.select__list
         %li.list__type.inactive__btn
-          = link_to "一覧", root_path
+          = link_to "おすすめ", recommend_comics_path
+        %li.list__type.inactive__btn
+          = link_to "一覧", authors_path
         %li.list__type.active__btn
           = link_to "検索", comics_path
     .display

--- a/app/views/comics/_top-three.html.haml
+++ b/app/views/comics/_top-three.html.haml
@@ -2,21 +2,22 @@
   .main
     .select
       %ul.select__list
-        %li.list__type.inactive__btn
-          = link_to "おすすめ", recommend_comics_path
+        %li.list__type.active__btn
+          = link_to "おすすめ", comics_path
         %li.list__type.inactive__btn
           = link_to "一覧", authors_path
-        %li.list__type.active__btn
+        %li.list__type.inactive__btn
           = link_to "検索", comics_path
+    
     .display__search
       .search-result__box
-        %p.search-result 検索結果
-        - if @comics.present?
+        %p.search-result 管理者のおすすめ作品
+        - if @comics_recommend.present?
           %ul.display__list
-            %p.search-result__count
-              = "#{@comics_count.count}件見つかりました"
+            -# %p.search-result__count
+              -# = "#{@comics_count.count}件見つかりました"
             .comics-box__list
-              - @comics.each do |comic|
+              - @comics_recommend.each do |comic|
                 %li.comic-box__result
                   .up-left
                   .under-right
@@ -34,8 +35,8 @@
                     .comic-box__result__summary
                       = comic.summary
             %p.displayed__results
-              = "#{@comics_count.count}件中、#{@comics.count}件表示しています"
+              -# = "#{@comics_count.count}件中、#{@comics.count}件表示しています"
         - else
           %p.no__search-result 条件に一致する作品はありません
-        = paginate @comics
+        = paginate @comics_recommend
   = render "authors/side"

--- a/app/views/comics/recommend.html.haml
+++ b/app/views/comics/recommend.html.haml
@@ -1,0 +1,3 @@
+.wrapper
+  = render "authors/header"
+  = render "top-three"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,10 +7,11 @@ Rails.application.routes.draw do
     sessions: 'users/sessions'
   }
   get '/users', to: redirect("/users/sign_up")    ##新規登録時renderでパスが/usersになるので、そこでリロードしたときにエラーが出てしまう（それ防止のためにリダイレクトさせる）
-  root "authors#index"
+  root "comics#recommend"
   resources :comics, only: [:index, :new, :create, :show] do
     collection do
       get 'search'
+      get 'recommend'
     end
     resource :bookmarks, only: [:create, :destroy]
     resources :comments, only: [:index, :create, :destroy]


### PR DESCRIPTION
# WHAT
 - おすすめ作品の一覧表示のビューを作成
 - recommend_idが1のcomicが該当する
 - comicsコントローラに新しくrecommendアクションを追加し、それをroot_pathに変更
 - アプリを開いた際に、管理者のおすすめ作品がデフォルトになるように変更
 - recommendアクション追加したため、管理者権限の方も調整
   - abilityモデルに、recommendアクションを誰でもOKにした
 - SCSSは検索結果表示のデザインを流用
 - ページネーションは10作品ごと

 - みため↓↓↓
<img width="1440" alt="スクリーンショット 2020-11-09 16 47 16" src="https://user-images.githubusercontent.com/69382240/98513461-3d695f80-22ab-11eb-8234-9ead5f37b36a.png">


# WHY
 - 元々、投稿作品一覧をroot_pathに設定していたが、作品名・作者名のみで質素な見た目になっていたため、画像ありのトップページに変更したかった
 - 一覧表示を全て画像こみで表示しても、個人的に見辛いと感じたため、おすすめをrootにした
 - アプリのポイントとして、新規より、再読ユーザーをターゲットにしているため懐かしい完結済の作品をrootにしたほうが直感的に扱いやすくなると思うため