### PR TITLE
comicsテーブルにカラム追加

### DIFF
--- a/app/controllers/authors_controller.rb
+++ b/app/controllers/authors_controller.rb
@@ -3,7 +3,7 @@ class AuthorsController < ApplicationController
 
   def index
     @authors = Author.all
-    @comics = Comic.all.page(params[:page]).per(15)
+    @comics = Comic.order("name_kana").page(params[:page]).per(15)
     @comic = Comic.order(created_at: :desc).limit(5)
     @comic_one = Comic.find(1)
     @comic_two = Comic.find(7)
@@ -85,22 +85,22 @@ class AuthorsController < ApplicationController
   private
 
   def author_params
-    params.require(:author).permit(:name, comics_attributes: [:name, :image, :number_of_books, :summary, :review, :booknumber_id, :recommend_id, genre_ids: []])
+    params.require(:author).permit(:name, comics_attributes: [:name, :name_kana, :image, :number_of_books, :summary, :review, :booknumber_id, :recommend_id, genre_ids: []])
   end
 
   def update_author_params
-    params.require(:author).permit(:name, comics_attributes: [:name, :image, :number_of_books, :summary, :review, :booknumber_id, :recommend_id, {genre_ids: []}, :_destroy, :id])
+    params.require(:author).permit(:name, comics_attributes: [:name, :name_kana, :image, :number_of_books, :summary, :review, :booknumber_id, :recommend_id, {genre_ids: []}, :_destroy, :id])
   end
 
   def comic_params
-    params.require(:author).require(:comics_attributes).require("0").permit(:name, :image, :number_of_books, :summary, :review, :booknumber_id, :recommend_id, genre_ids: []).merge(author_id: @author.id)
+    params.require(:author).require(:comics_attributes).require("0").permit(:name, :name_kana, :image, :number_of_books, :summary, :review, :booknumber_id, :recommend_id, genre_ids: []).merge(author_id: @author.id)
   end
 
   def update_author_comic_params     ##元の作者変更しなかった場合こっち（変更前の作者idをmarge）
-    params.require(:author).require(:comic).permit(:name, :image, :number_of_books, :summary, :review, :booknumber_id, :recommend_id, genre_ids: []).merge(author_id: @author.id)
+    params.require(:author).require(:comic).permit(:name, :name_kana, :image, :number_of_books, :summary, :review, :booknumber_id, :recommend_id, genre_ids: []).merge(author_id: @author.id)
   end
 
   def update_author_db_find_comic_params     ##元の作者から変更した場合こっち（変更後の作者idをmarge）
-    params.require(:author).require(:comic).permit(:name, :image, :number_of_books, :summary, :review, :booknumber_id, :recommend_id, genre_ids: []).merge(author_id: @author_db_find.id)
+    params.require(:author).require(:comic).permit(:name, :name_kana, :image, :number_of_books, :summary, :review, :booknumber_id, :recommend_id, genre_ids: []).merge(author_id: @author_db_find.id)
   end
 end

--- a/app/models/comic.rb
+++ b/app/models/comic.rb
@@ -13,6 +13,7 @@ class Comic < ApplicationRecord
   validates :number_of_books, presence: true
   validates :summary, presence: true
   validates :review, presence: true
+  validates :name_kana, presence: true
 
   mount_uploader :image, ImageUploader
 

--- a/app/views/authors/edit.html.haml
+++ b/app/views/authors/edit.html.haml
@@ -23,6 +23,11 @@
               = c.text_field :name, class: "form_default", required: true, placeholder: "例）アライブ 最終進化的少年"
               %br
             .field
+              = c.label :name_kana, "読み方"
+              %br
+              = c.text_field :name_kana, class: "form_default", required: true, placeholder: "例）あらいぶさいしゅうしんかてきしょうねん"
+              %br
+            .field
               = c.label :number_of_books, "巻数"
               %br
               = c.number_field :number_of_books, class: "form_number", required: true

--- a/app/views/authors/new.html.haml
+++ b/app/views/authors/new.html.haml
@@ -22,6 +22,11 @@
               = c.text_field :name, class: "form_default", required: true, placeholder: "例）アライブ 最終進化的少年"
               %br
             .field
+              = c.label :name_kana, "読み方"
+              %br
+              = c.text_field :name_kana, class: "form_default", required: true, placeholder: "例）あらいぶさいしゅうしんかてきしょうねん"
+              %br
+            .field
               = c.label :number_of_books, "巻数"
               %br
               = c.number_field :number_of_books, class: "form_number", required: true

--- a/db/migrate/20201110054826_add_column_kana_to_comics.rb
+++ b/db/migrate/20201110054826_add_column_kana_to_comics.rb
@@ -1,0 +1,5 @@
+class AddColumnKanaToComics < ActiveRecord::Migration[6.0]
+  def change
+    add_column :comics, :name_kana, :string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_09_021553) do
+ActiveRecord::Schema.define(version: 2020_11_10_054826) do
 
   create_table "authors", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -47,6 +47,7 @@ ActiveRecord::Schema.define(version: 2020_11_09_021553) do
     t.bigint "author_id"
     t.integer "booknumber_id", null: false
     t.integer "recommend_id", null: false
+    t.string "name_kana", null: false
     t.index ["author_id"], name: "index_comics_on_author_id"
   end
 


### PR DESCRIPTION
# WHAT
 - comicsテーブルにname_kanaカラムを追加
 - 作品の読み方を、ひらがなで登録できるようにした
 - 一覧表示のページで、作品をid順ではなくname_kana基準で50音順にした
 - comicモデルにバリデーション追加→name_kanaカラムにpresence:trueをつけた
 - authors/newとedit.htmlに、name_kanaの入力フォームを追加
 - authors_controllerのストロングパラメータにname_kanaを追加し、許可するようにした


# WHY
 - 現状だと、一覧表示の画面での表示順が登録された順になっていた
 - 50音順のほうが、並びを理解しやすいと思ったため
 - DBに、あえて作品の読み方を平仮名で統一しておくことで、アルファベットの作品などの読み方も50音に統一できるため
 - 管理者目線でも、利便性向上が見込めたため