### PR TITLE
管理者画面の再作成（自作）

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -7,3 +7,4 @@
 @import "modules/comics";
 @import "modules/users";
 @import "modules/comments";
+@import "modules/admins"

--- a/app/assets/stylesheets/modules/admins.scss
+++ b/app/assets/stylesheets/modules/admins.scss
@@ -1,0 +1,23 @@
+.admin__table {
+  border: double 5px #93e093;
+  margin-left: 100px;
+  width: 750px;
+  background-color: #f5f5f5;
+  tr {
+    th {
+      width: 250px;
+      padding: 10px;
+      border-bottom: solid 3px white;
+      border-left: solid 2px white;
+      text-align: center;
+      font-size: 24px;
+      font-weight: bold;
+    }
+    td {
+      padding: 10px;
+      border: solid 2px white;
+      text-align: center;
+      font-size: 20px;
+    }
+  }
+}

--- a/app/assets/stylesheets/modules/admins.scss
+++ b/app/assets/stylesheets/modules/admins.scss
@@ -3,8 +3,8 @@
   margin-left: 100px;
   width: 750px;
   background-color: #f5f5f5;
-  tr {
-    th {
+  tr {      //表の行
+    th {    //見出し
       width: 250px;
       padding: 10px;
       border-bottom: solid 3px white;
@@ -13,7 +13,7 @@
       font-size: 24px;
       font-weight: bold;
     }
-    td {
+    td {      //内容
       padding: 10px;
       border: solid 2px white;
       text-align: center;

--- a/app/assets/stylesheets/modules/comics.scss
+++ b/app/assets/stylesheets/modules/comics.scss
@@ -227,7 +227,7 @@
   padding: 40px 40px;
   margin: 40px auto 0;
   width: 1300px;
-
+  min-height: 600px;
 
   .search-result__box {
     .search-result {

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -5,6 +5,11 @@ class Admin::UsersController < ApplicationController
     @users = User.all.order("created_at DESC")
     @comics = Comic.all.order("created_at DESC")
     @authors = Author.all.order("created_at DESC")
+    @genres = Genre.all.order("created_at DESC")
+    @user = User.order(updated_at: :desc).limit(1)
+    @comic = Comic.order(updated_at: :desc).limit(1)
+    @author = Author.order(updated_at: :desc).limit(1)
+    @genre = Genre.order(updated_at: :desc).limit(1)
   end
 
   private

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,0 +1,14 @@
+class Admin::UsersController < ApplicationController
+  before_action :admin_user
+
+  def index
+    @users = User.all.order("created_at DESC")
+    @comics = Comic.all.order("created_at DESC")
+    @authors = Author.all.order("created_at DESC")
+  end
+
+  private
+  def admin_user
+    redirect_to(root_path) unless current_user.admin?
+  end
+end

--- a/app/views/admin/users/index.html.haml
+++ b/app/views/admin/users/index.html.haml
@@ -1,0 +1,38 @@
+.wrapper__bookmark
+
+  .header__user
+    %p.app-title__box
+      = link_to "Manga-App", root_path, class: "app-title"
+
+  .display__bookmark
+    %section.search-result__box
+      %h2.search-result 管理者画面
+      %table.admin__table
+        %tr
+          %th モデル
+          %th 登録数
+          %th 最新更新日
+        %tr
+          %td 作品(Comic)
+          %td=@comics.length
+          %td
+            - @comic.each do |comic|
+              = l comic.created_at, format: :admintime
+        %tr
+          %td 作者(Author)
+          %td=@authors.length
+          %td
+            - @author.each do |author|
+              = l author.created_at, format: :admintime
+        %tr
+          %td ジャンル(Genre)
+          %td=@genres.length
+          %td
+            - @genre.each do |genre|
+              = l genre.created_at, format: :admintime
+        %tr
+          %td ユーザー(User)
+          %td=@users.length
+          %td
+            - @user.each do |user|
+              = l user.created_at, format: :admintime

--- a/app/views/admin/users/index.html.haml
+++ b/app/views/admin/users/index.html.haml
@@ -17,22 +17,22 @@
           %td=@comics.length
           %td
             - @comic.each do |comic|
-              = l comic.created_at, format: :admintime
+              = l comic.updated_at, format: :admintime
         %tr
           %td 作者(Author)
           %td=@authors.length
           %td
             - @author.each do |author|
-              = l author.created_at, format: :admintime
+              = l author.updated_at, format: :admintime
         %tr
           %td ジャンル(Genre)
           %td=@genres.length
           %td
             - @genre.each do |genre|
-              = l genre.created_at, format: :admintime
+              = l genre.updated_at, format: :admintime
         %tr
           %td ユーザー(User)
           %td=@users.length
           %td
             - @user.each do |user|
-              = l user.created_at, format: :admintime
+              = l user.updated_at, format: :admintime

--- a/app/views/authors/_header.html.haml
+++ b/app/views/authors/_header.html.haml
@@ -45,7 +45,7 @@
               %p 作品投稿
           %li.menu_list
             .maru_btn
-            = link_to "#" do
+            = link_to admin_users_path do
               %p 管理者画面
         %li.menu_list
           .maru_btn

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -10,8 +10,8 @@ Rails.application.configure do
   config.eager_load = false
 
   # Show full error reports.
-  # config.consider_all_requests_local = true
-  config.consider_all_requests_local = false
+  config.consider_all_requests_local = true
+  # config.consider_all_requests_local = false
 
   # Enable/disable caching. By default caching is disabled.
   # Run rails dev:cache to toggle caching.

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -205,4 +205,5 @@ ja:
       long: "%Y/%m/%d %H:%M"
       short: "%m/%d %H:%M"
       veryshort: "%m/%d"
+      admintime: "%Y.%m.%d"
     pm: 午後

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,9 @@ Rails.application.routes.draw do
   get 'bookmarks/create'
   get 'bookmarks/destroy'
   # mount RailsAdmin::Engine => '/admin', as: 'rails_admin'
+  namespace :admin do
+    resources :users
+  end
   devise_for :users, controllers: {
     registrations: 'users/registrations',
     sessions: 'users/sessions'


### PR DESCRIPTION
# WHAT
 - 管理者画面の作成に再度挑戦した
 - Gemを扱い切れないため、自作で簡易な画面にすることにした
 - admin用のルーティングとコントローラ作成し、管理者画面のビューも作成
 - 管理者画面の細かいビューの修正もした
 - ドロワーメニューから管理者画面へ遷移できるようにした
<img width="1440" alt="スクリーンショット 2020-11-15 13 08 30" src="https://user-images.githubusercontent.com/69382240/99162678-a9ccde80-2743-11eb-8b37-b27b20a39018.png">


# WHY
 - Gemで作っていたときは、扱い切れない ＋ 必要性が十分に感じれなかったため削除したが、登録数などを一目で確認できた方が使い勝手が良いと思い、再度作成するようにした
 - 自身の実力向上のため