### PR TITLE
アプリ名の変更

### DIFF
--- a/app/assets/stylesheets/modules/authors.scss
+++ b/app/assets/stylesheets/modules/authors.scss
@@ -17,6 +17,17 @@
 // ヘッダーのCSS
 .header {
   height: auto;
+  .app-title__box {
+    margin-right: 10px;
+    .app-title {
+      padding: 10px;
+      border-radius: 50px;
+      color:  #71dd9e;
+      font-weight: bold;
+      font-size: 20px;
+      border: solid 2px #71dd9e;
+    }
+  }
   #menu {
     width: 310px;
     height: 100vh;
@@ -170,22 +181,6 @@
             margin-right: 30px;
           }
         }
-      }
-    }
-  }
-
-  &__under {
-    margin-top: 20px;
-    padding: 10px;
-    .app-title__box {
-      font-size: 50px;
-      font-weight: bold;
-      text-align: center;
-      a {
-        padding: 20px;
-        background-color: #71dd9e;
-        border-radius: 50px;
-        color: white;
       }
     }
   }

--- a/app/views/admin/users/index.html.haml
+++ b/app/views/admin/users/index.html.haml
@@ -2,7 +2,7 @@
 
   .header__user
     %p.app-title__box
-      = link_to "Manga-App", root_path, class: "app-title"
+      = link_to "Comic-Remember", root_path, class: "app-title"
 
   .display__bookmark
     %section.search-result__box

--- a/app/views/authors/_header.html.haml
+++ b/app/views/authors/_header.html.haml
@@ -1,5 +1,8 @@
 .header 
   .header__up
+    %p.app-title__box
+      = link_to root_path, class: "app-title" do
+        Comic-Remember
     .header__up__left
       %span 管理者のおすすめ漫画の紹介、備忘録なアプリとなっています。コメントもご自由にお書きください。
     .header__up__right
@@ -21,10 +24,6 @@
         
 
   .header__under
-    %p.app-title__box
-      -# = image_tag "manga-app_logo.png", width: "50px", height: "50px"
-      = link_to root_path, class: "app-title" do
-        Manga-App
   - if user_signed_in?
     %nav#menu
       .peke.peke-none

--- a/app/views/authors/edit.html.haml
+++ b/app/views/authors/edit.html.haml
@@ -2,7 +2,7 @@
 
   .header__comic
     %p.app-title__box
-      = link_to "Manga-App", root_path, class: "app-title"
+      = link_to "Comic-Remember", root_path, class: "app-title"
 
   .main__comic-box
     %section.main__comic-box__center

--- a/app/views/authors/new.html.haml
+++ b/app/views/authors/new.html.haml
@@ -2,7 +2,7 @@
 
   .header__comic
     %p.app-title__box
-      = link_to "Manga-App", root_path, class: "app-title"
+      = link_to "Comic-Remember", root_path, class: "app-title"
 
   .main__comic-box
     %section.main__comic-box__center

--- a/app/views/comments/index.html.haml
+++ b/app/views/comments/index.html.haml
@@ -2,7 +2,7 @@
 
   .header__user
     %p.app-title__box
-      = link_to "Manga-App", root_path, class: "app-title"
+      = link_to "Comic-Remember", root_path, class: "app-title"
 
   .display__comment
     .display__comment__left

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -2,7 +2,7 @@
 
   .header__user
     %p.app-title__box
-      = link_to "Manga-App", root_path, class: "app-title"
+      = link_to "Comic-Remember", root_path, class: "app-title"
   .main__user-box
     %section.main__user-box__center
       %h2 アカウント編集

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -2,7 +2,7 @@
 
   .header__user
     %p.app-title__box
-      = link_to "Manga-App", root_path, class: "app-title"
+      = link_to "Comic-Remember", root_path, class: "app-title"
   .main__user-box
     %section.main__user-box__center
       %h2 アカウント新規作成

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -2,7 +2,7 @@
 
   .header__user
     %p.app-title__box
-      = link_to "Manga-App", root_path, class: "app-title"
+      = link_to "Comic-Remember", root_path, class: "app-title"
   .main__user-box
     %section.main__user-box__center
       %h2 ログイン画面

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -3,7 +3,7 @@
   %head
     = favicon_link_tag 'manga-app_logo.png'
     %meta{:content => "text/html; charset=UTF-8", "http-equiv" => "Content-Type"}/
-    %title MangaApp
+    %title Comic-R
     = csrf_meta_tags
     = csp_meta_tag
     = stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload'

--- a/public/404.html
+++ b/public/404.html
@@ -90,7 +90,7 @@
   <!-- This file lives in public/404.html -->
   <div class="header__not__found">
     <div class="app-title__box">
-      <a class="app-title" href="/">Manga-App</a>
+      <a class="app-title" href="/">Comic-Remember</a>
     </div>
   </div>
   <div class="dialog">


### PR DESCRIPTION
# WHAT
 - アプリ名をManga-AppからComic-Rememberに変更した
 - headのtitleタグも変更
 - ヘッダーで、Manga-Appになっている箇所を全て変更
 - 見た目↓↓↓
<img width="1440" alt="スクリーンショット 2020-11-15 15 35 07" src="https://user-images.githubusercontent.com/69382240/99178600-2669b800-2758-11eb-9ce7-e5fbc9ae7671.png">



# WHY
 - 変更前（Manga-App）でもよかったが、アプリのアピールポイントを考えたとき、Comic-Rememberの方が合っていると思ったため
 - デザインもど真ん中におくより、ヘッダーの中に溶け込ませた方が見た目が変更前よりきれいになったため