### PR TITLE
作者の作品一覧ページ作成

### DIFF
--- a/app/assets/stylesheets/modules/authors.scss
+++ b/app/assets/stylesheets/modules/authors.scss
@@ -156,6 +156,7 @@
           top: 50px;
           right: 0;
           font-size: 12px;
+          z-index: 2;
         }
         .sign-up__merit:before {    //吹き出しの矢印CSS
           content: "";

--- a/app/controllers/authors_controller.rb
+++ b/app/controllers/authors_controller.rb
@@ -99,6 +99,10 @@ class AuthorsController < ApplicationController
     end
   end
 
+  def show
+    @author = Author.find(params[:id])
+  end
+
   private
 
   def author_params

--- a/app/views/authors/_header.html.haml
+++ b/app/views/authors/_header.html.haml
@@ -35,7 +35,7 @@
             %p アカウント編集
         %li.menu_list
           .maru_btn
-          = link_to user_showbookmark_path(@comic, id: current_user) do
+          = link_to user_showbookmark_path(current_user) do
             %p ブックマーク一覧
         - if user_signed_in? && current_user.admin?
           %li.menu_list

--- a/app/views/authors/new.html.haml
+++ b/app/views/authors/new.html.haml
@@ -3,7 +3,6 @@
   .header__comic
     %p.app-title__box
       = link_to "Comic-Remember", root_path, class: "app-title"
-
   .main__comic-box
     %section.main__comic-box__center
       %h2 作品投稿

--- a/app/views/authors/show.html.haml
+++ b/app/views/authors/show.html.haml
@@ -1,0 +1,29 @@
+.wrapper__bookmark
+  -# ブックマーク一覧のデザインをそののまま使う
+  .header__user
+    %p.app-title__box
+      = link_to "Comic-Remember", root_path, class: "app-title"
+
+  .display__bookmark
+    %section.search-result__box
+      %h2.search-result
+        = @author.name
+        の作品一覧
+      %ul.display__list
+        .bookmark-box__list
+          - @author.comics.each do |comic|
+            %li.comic-box__result
+              .up-left
+              .under-right
+              = link_to comic_path(comic.id), class: "comic-box__link" do
+                .comic-box__result__data
+                  %p.comic__result__image
+                    = image_tag comic.image.url
+                  .comic__result__name__list
+                    %p.comic__result__name
+                      %span
+                        = comic.name
+                    %p.comic__result__author-name
+                      = comic.author.name
+                .comic-box__result__summary
+                  = comic.summary

--- a/app/views/comics/show.html.haml
+++ b/app/views/comics/show.html.haml
@@ -29,7 +29,8 @@
             .show__info__authorName
               %span.infoTitle 作者名　：
               %span.blueColor
-                = @author.name
+                = link_to author_path(@author), class: "blueColor" do
+                  = @author.name
             .show__info__bookNumber
               %span.infoTitle 既刊　　：
               %span.blueColor

--- a/app/views/users/showbookmark.html.haml
+++ b/app/views/users/showbookmark.html.haml
@@ -2,7 +2,7 @@
 
   .header__user
     %p.app-title__box
-      = link_to "Manga-App", root_path, class: "app-title"
+      = link_to "Comic-Remember", root_path, class: "app-title"
 
   .display__bookmark
     %section.search-result__box


### PR DESCRIPTION
# WHAT
 - 作者の漫画一覧を作成した
 - authorのshowアクション作成
 - 漫画詳細の作者名にlinkを構え、クリックすることで遷移するようにした
 - ブックマーク一覧のlink_toの引数の変更
   - (@comic, id: currenr_user)は正しくなかったため、(currenr_user)に修正

 - ブックマーク一覧のページのデザインをそのまま使用した
   - タイトルがManga-Appのままだったので変更した
 - トップページの新規登録btnの説明文のz-indexを2設定し、スライド画像より上に持ってきた

 - ↓↓↓
<img width="1440" alt="スクリーンショット 2020-11-16 15 39 40" src="https://user-images.githubusercontent.com/69382240/99220402-f38bf680-2821-11eb-8cea-d287a485e04c.png">


# WHY
 - 実際使っていて、作者の作品一覧をみたい場面があるため
 - 使い勝手向上のため