### PR TITLE
作者一覧ページの作成

### DIFF
--- a/app/assets/stylesheets/modules/authors.scss
+++ b/app/assets/stylesheets/modules/authors.scss
@@ -218,16 +218,12 @@
         margin-left: 5px;
         a {
           font-size: 20px;
-          // font-weight: bold;
           text-decoration: none;
         }
       }
       .inactive__btn:hover {
         opacity: 0.8;
         background-color: white;
-      }
-      a:hover {
-        // color: lightcoral;
       }
       .active__btn {
         background-color: white;
@@ -252,7 +248,6 @@
           text-decoration: none;
           margin-bottom: 10px;
           padding: 5px;
-          // border-bottom: 1px solid lightgreen;
           max-width: 263px;
           min-width: 263px;
           &__link {
@@ -262,8 +257,8 @@
           &__data {
             display: flex;
             justify-content: space-between;
-            font-size: 14px;
-            color: #1a73e8;
+            font-size: 16px;
+            border-bottom: dotted 1px #1a73e8;
           }
           .comic-box__data:hover {
             color: lightcoral;

--- a/app/assets/stylesheets/modules/authors.scss
+++ b/app/assets/stylesheets/modules/authors.scss
@@ -218,15 +218,16 @@
         margin-left: 5px;
         a {
           font-size: 20px;
-          font-weight: bold;
+          // font-weight: bold;
           text-decoration: none;
         }
       }
       .inactive__btn:hover {
-        opacity: 0.5;
+        opacity: 0.8;
+        background-color: white;
       }
       a:hover {
-        color: lightcoral;
+        // color: lightcoral;
       }
       .active__btn {
         background-color: white;
@@ -244,21 +245,29 @@
         color: rgb(147, 224, 147);
         margin-bottom: 30px;
       }
-      .comic-box {
-        text-decoration: none;
-        margin-bottom: 30px;
-        padding: 5px;
-        border-bottom: 1px solid lightgreen;
-        &__link {
-          font-size: 20px;
+      .display__list {
+        display: flex;
+        flex-wrap: wrap;    //２列にして、改行になるようにした。下で設定したwidthが親の溢れると改行になる
+        .comic-box {
           text-decoration: none;
-        }
-        &__data {
-          display: flex;
-          justify-content: space-between;
-        }
-        .comic-box__data:hover {
-          color: lightcoral;
+          margin-bottom: 10px;
+          padding: 5px;
+          // border-bottom: 1px solid lightgreen;
+          max-width: 263px;
+          min-width: 263px;
+          &__link {
+            font-size: 20px;
+            text-decoration: none;
+          }
+          &__data {
+            display: flex;
+            justify-content: space-between;
+            font-size: 14px;
+            color: #1a73e8;
+          }
+          .comic-box__data:hover {
+            color: lightcoral;
+          }
         }
       }
     }

--- a/app/controllers/authors_controller.rb
+++ b/app/controllers/authors_controller.rb
@@ -2,8 +2,8 @@ class AuthorsController < ApplicationController
 
   def index
     @authors = Author.all
-    @comics = Comic.order("name_kana").page(params[:page]).per(15)
-    @comic = Comic.order(created_at: :desc).limit(5)
+    # @comics = Comic.order("name_kana").page(params[:page]).per(15)
+    @comic_info = Comic.order(created_at: :desc).limit(5)
     @comic_one = Comic.find_by(id: 1)
     @comic_two = Comic.find_by(id: 7)
     @comic_three = Comic.find_by(id: 3)

--- a/app/controllers/comics_controller.rb
+++ b/app/controllers/comics_controller.rb
@@ -1,6 +1,15 @@
 class ComicsController < ApplicationController
 
   def index
+  end
+
+  def show
+    @comic = Comic.find(params[:id])
+    @author = Author.find(@comic.author.id)
+    @comic_genre = @comic.genres.pluck(:genre)
+  end
+
+  def searchscreen
     @q = Comic.ransack(params[:q])
     @genres = Genre.all
     @comics = @q.result(distinct: true)
@@ -10,25 +19,6 @@ class ComicsController < ApplicationController
     @comic_three = Comic.find_by(id: 3)
     @comic_four = Comic.find_by(id: 4)
     @comic_five = Comic.find_by(id: 5)
-  end
-
-  # def new
-  #   @comic = Comic.new
-  # end
-
-  # def create
-  #   @comic = Comic.new(comic_params)
-  #   if @comic.save
-  #     redirect_to root_path, notice: "投稿を完了しました"
-  #   else
-  #     render :new
-  #   end
-  # end
-
-  def show
-    @comic = Comic.find(params[:id])
-    @author = Author.find(@comic.author.id)
-    @comic_genre = @comic.genres.pluck(:genre)
   end
 
   def search

--- a/app/controllers/comics_controller.rb
+++ b/app/controllers/comics_controller.rb
@@ -1,6 +1,14 @@
 class ComicsController < ApplicationController
 
   def index
+    # @comics = Comic.order("name_kana").page(params[:page]).per(15)
+    @comics = Comic.order("name_kana")
+    @comic_info = Comic.order(created_at: :desc).limit(5)
+    @comic_one = Comic.find_by(id: 1)
+    @comic_two = Comic.find_by(id: 7)
+    @comic_three = Comic.find_by(id: 3)
+    @comic_four = Comic.find_by(id: 4)
+    @comic_five = Comic.find_by(id: 5)
   end
 
   def show
@@ -9,11 +17,11 @@ class ComicsController < ApplicationController
     @comic_genre = @comic.genres.pluck(:genre)
   end
 
-  def searchscreen
+  def searchscreen    ##検索画面
     @q = Comic.ransack(params[:q])
     @genres = Genre.all
     @comics = @q.result(distinct: true)
-    @comic = Comic.order(created_at: :desc).limit(5)
+    @comic_info = Comic.order(created_at: :desc).limit(5)
     @comic_one = Comic.find_by(id: 1)
     @comic_two = Comic.find_by(id: 7)
     @comic_three = Comic.find_by(id: 3)
@@ -21,11 +29,11 @@ class ComicsController < ApplicationController
     @comic_five = Comic.find_by(id: 5)
   end
 
-  def search
+  def search      ##検索結果の画面c
     @q = Comic.ransack(params[:q])
     @comics = @q.result(distinct: true)
     @comics_count = @q.result(distinct: true)
-    @comic = Comic.order(created_at: :desc).limit(5)
+    @comic_info = Comic.order(created_at: :desc).limit(5)
     @comics = @comics.page(params[:page]).per(10)
     @comic_one = Comic.find_by(id: 1)
     @comic_two = Comic.find_by(id: 7)
@@ -37,7 +45,7 @@ class ComicsController < ApplicationController
   def recommend
     @authors = Author.all
     # @comics = Comic.all.page(params[:page]).per(10)   ##ページネーション
-    @comic = Comic.order(created_at: :desc).limit(5)    ##サイドバーの登録最新から5件取得
+    @comic_info = Comic.order(created_at: :desc).limit(5)    ##サイドバーの登録最新から5件取得
     @comics_recommend = Comic.where(recommend_id: 1).page(params[:page]).per(10)    ##おすすめ作品を取得、ページネーションを10作品ごと
     @comic_one = Comic.find_by(id: 1)
     @comic_two = Comic.find_by(id: 7)

--- a/app/views/authors/_main.html.haml
+++ b/app/views/authors/_main.html.haml
@@ -3,20 +3,19 @@
     %ul.select__list
       %li.list__type.inactive__btn
         = link_to "おすすめ", recommend_comics_path
+      %li.list__type.inactive__btn
+        = link_to "作品一覧", comics_path
       %li.list__type.active__btn
-        = link_to "一覧", authors_path
+        = link_to "作者一覧", authors_path
       %li.list__type.inactive__btn
         = link_to "検索", searchscreen_comics_path
   .display
     .comics__all-box
       %p.comics__all 紹介作品一覧
       %ul.display__list
-        - @comics.each do |comic|
+        - @authors.each do |author|
           %li.comic-box
-            = link_to comic_path(comic.id), class: "comic-box__link" do
+            = link_to author_path(author), class: "comic-box__link" do
               .comic-box__data
                 %p 
-                  = comic.name
-                %p 
-                  = comic.author.name
-    = paginate @comics
+                  = author.name

--- a/app/views/authors/_main.html.haml
+++ b/app/views/authors/_main.html.haml
@@ -6,7 +6,7 @@
       %li.list__type.active__btn
         = link_to "一覧", authors_path
       %li.list__type.inactive__btn
-        = link_to "検索", comics_path
+        = link_to "検索", searchscreen_comics_path
   .display
     .comics__all-box
       %p.comics__all 紹介作品一覧

--- a/app/views/authors/_main.html.haml
+++ b/app/views/authors/_main.html.haml
@@ -11,11 +11,11 @@
         = link_to "検索", searchscreen_comics_path
   .display
     .comics__all-box
-      %p.comics__all 紹介作品一覧
+      %p.comics__all 作者一覧
       %ul.display__list
         - @authors.each do |author|
           %li.comic-box
             = link_to author_path(author), class: "comic-box__link" do
               .comic-box__data
-                %p 
-                  = author.name
+                = author.name
+                %p

--- a/app/views/authors/_side.html.haml
+++ b/app/views/authors/_side.html.haml
@@ -38,7 +38,7 @@
     %p
       %span お知らせ
     %ul.side__under__list
-      - @comic.each do |comic|
+      - @comic_info.each do |comic|
         %li.side__under__list__notice
         .notice__date
           = l comic.created_at, format: :veryshort

--- a/app/views/comics/_top-four.html.haml
+++ b/app/views/comics/_top-four.html.haml
@@ -1,0 +1,25 @@
+.top
+  .main
+    .select
+      %ul.select__list
+        %li.list__type.inactive__btn
+          = link_to "おすすめ", recommend_comics_path
+        %li.list__type.active__btn
+          = link_to "作品一覧", comics_path
+        %li.list__type.inactive__btn
+          = link_to "作者一覧", authors_path
+        %li.list__type.inactive__btn
+          = link_to "検索", searchscreen_comics_path
+    .display
+      .comics__all-box
+        %p.comics__all 紹介作品一覧
+        %ul.display__list
+          - @comics.each do |comic|
+            %li.comic-box
+              = link_to comic_path(comic.id), class: "comic-box__link" do
+                .comic-box__data
+                  %p 
+                    = comic.name
+
+
+  = render "authors/side"

--- a/app/views/comics/_top-four.html.haml
+++ b/app/views/comics/_top-four.html.haml
@@ -12,7 +12,7 @@
           = link_to "検索", searchscreen_comics_path
     .display
       .comics__all-box
-        %p.comics__all 紹介作品一覧
+        %p.comics__all 作品一覧
         %ul.display__list
           - @comics.each do |comic|
             %li.comic-box

--- a/app/views/comics/_top-one.html.haml
+++ b/app/views/comics/_top-one.html.haml
@@ -7,7 +7,7 @@
         %li.list__type.inactive__btn
           = link_to "一覧", authors_path
         %li.list__type.active__btn
-          = link_to "検索", comics_path
+          = link_to "検索", searchscreen_comics_path
     .display
       .search-box
         %p 探したい条件で検索することができます

--- a/app/views/comics/_top-one.html.haml
+++ b/app/views/comics/_top-one.html.haml
@@ -5,7 +5,9 @@
         %li.list__type.inactive__btn
           = link_to "おすすめ", recommend_comics_path
         %li.list__type.inactive__btn
-          = link_to "一覧", authors_path
+          = link_to "作品一覧", comics_path
+        %li.list__type.inactive__btn
+          = link_to "作者一覧", authors_path
         %li.list__type.active__btn
           = link_to "検索", searchscreen_comics_path
     .display

--- a/app/views/comics/_top-three.html.haml
+++ b/app/views/comics/_top-three.html.haml
@@ -5,7 +5,9 @@
         %li.list__type.active__btn
           = link_to "おすすめ", comics_path
         %li.list__type.inactive__btn
-          = link_to "一覧", authors_path
+          = link_to "作品一覧", comics_path
+        %li.list__type.inactive__btn
+          = link_to "作者一覧", authors_path
         %li.list__type.inactive__btn
           = link_to "検索", searchscreen_comics_path
     

--- a/app/views/comics/_top-three.html.haml
+++ b/app/views/comics/_top-three.html.haml
@@ -7,7 +7,7 @@
         %li.list__type.inactive__btn
           = link_to "一覧", authors_path
         %li.list__type.inactive__btn
-          = link_to "検索", comics_path
+          = link_to "検索", searchscreen_comics_path
     
     .display__search
       .search-result__box

--- a/app/views/comics/_top-two.html.haml
+++ b/app/views/comics/_top-two.html.haml
@@ -5,7 +5,9 @@
         %li.list__type.inactive__btn
           = link_to "おすすめ", recommend_comics_path
         %li.list__type.inactive__btn
-          = link_to "一覧", authors_path
+          = link_to "作品一覧", comics_path
+        %li.list__type.inactive__btn
+          = link_to "作者一覧", authors_path
         %li.list__type.active__btn
           = link_to "検索", searchscreen_comics_path
     .display__search

--- a/app/views/comics/_top-two.html.haml
+++ b/app/views/comics/_top-two.html.haml
@@ -7,7 +7,7 @@
         %li.list__type.inactive__btn
           = link_to "一覧", authors_path
         %li.list__type.active__btn
-          = link_to "検索", comics_path
+          = link_to "検索", searchscreen_comics_path
     .display__search
       .search-result__box
         %p.search-result 検索結果

--- a/app/views/comics/index.html.haml
+++ b/app/views/comics/index.html.haml
@@ -1,3 +1,3 @@
 .wrapper
   = render "authors/header"
-  = render "top-one"
+  = render "top-four"

--- a/app/views/comics/searchscreen.html.haml
+++ b/app/views/comics/searchscreen.html.haml
@@ -1,0 +1,3 @@
+.wrapper
+  = render "authors/header"
+  = render "top-one"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
   resources :comics, only: [:index, :new, :create, :show] do
     collection do
       get 'search'
+      get 'searchscreen'
       get 'recommend'
     end
     resource :bookmarks, only: [:create, :destroy]


### PR DESCRIPTION
# WHAT
 - これまでは、一覧ページとして一つしか用意していなかったので、作者と作品を分けてそれぞれ一覧ページを作成した
 - 新しくビューを用意する必要があるため、routes.rbのcomicの中にget 'searchscreen'を追加し、検索画面をここに変更した
 - 元々、検索画面に設定していたcomicsのindexを作品の一覧ページに、authorsのindexを作者一覧ページにした
 - ビューを変更したため、CSSも修正した
 - 変更後のビュー↓↓↓
<img width="1440" alt="スクリーンショット 2020-11-16 19 08 25" src="https://user-images.githubusercontent.com/69382240/99239949-1d074b00-283f-11eb-8f82-6b0095306b80.png">


# WHY
 - 作者の作品一覧ページを、一つ前の作業で行っていたため、作者のリンクもあったほうが使い勝手向上すると思い、作者一覧ページを作成した
 - 作者一覧から、作者を知る場合もあり、画面の情報量も増え見栄えもよくなる為