### PR TITLE
検索画面の修正・変更

### DIFF
--- a/app/assets/stylesheets/modules/comics.scss
+++ b/app/assets/stylesheets/modules/comics.scss
@@ -13,21 +13,31 @@
 
   &__word {
     margin-bottom: 30px;
-    #q_name_or_author_name_cont {
+    input {
       width: 100%;
       height: 40px;
       margin-top: 10px;
       padding: 0 10px;
+      outline: none;    //デフォルトで用意されてる青い線を消す
+    }
+    input:focus {     //フォーカス中は、緑のラインが出るようにする
+      border: solid 1px #c7e9d5;
+      box-shadow: inset 0 0 5px #71dd9e;
     }
   }
 
   &__genre {
     margin-bottom: 30px;
-    #q_genres_id_eq {
-      width: 100%;
+    select {
+      width: 300px;
       height: 40px;
       margin-top: 10px;
       padding: 0 10px;
+      outline: none;
+    }
+    select:focus {
+      border: solid 1px #c7e9d5;
+      box-shadow: inset 0 0 5px #71dd9e;
     }
   }
 
@@ -38,6 +48,7 @@
       width: 120px;
       margin-top: 10px;
       padding: 0 10px;
+      outline: none;
     }
 
     .wavy-line {
@@ -50,6 +61,12 @@
       height: 40px;
       width: 120px;
       padding: 0 10px;
+      outline: none;
+    }
+
+    input:focus {
+      border: solid 1px #c7e9d5;
+      box-shadow: inset 0 0 5px #71dd9e;
     }
   }
 

--- a/app/views/authors/edit.html.haml
+++ b/app/views/authors/edit.html.haml
@@ -15,7 +15,7 @@
             %br
             = a.text_field :name, class: "form_default", required: true, placeholder: "例）河島正 × あだちとか"
             %br
-          -# 19行目でモデルを指定、newの時はcomicsになっていると思う、acceptを使わない書き方になるのかな？？
+          -# 19行目fields_for(@comic)でモデルを指定、newの時はcomicsになっていると思う、acceptを使わない書き方になるのかな？？
           = a.fields_for(@comic) do |c|
             .field
               = c.label :name, "作品名"

--- a/app/views/comics/_top-one.html.haml
+++ b/app/views/comics/_top-one.html.haml
@@ -15,9 +15,13 @@
         %p 探したい条件で検索することができます
         = search_form_for @q, url: search_comics_path do |f|
           .search-box__word
-            = f.label :search, '作品名、作者名から探せます'
+            = f.label :search, '作品名から探せます'
             %br
-            = f.search_field :name_or_author_name_cont, placeholder: "(例)アライブ"
+            = f.search_field :name_or_name_kana_or_author_name_cont, placeholder: "(例)犬夜叉"
+          .search-box__word
+            = f.label :search, '作者名から探せます'
+            %br
+            = f.search_field :author_name_cont, placeholder: "(例)高橋留美子"
           .search-box__genre
             = f.label :genre_id_eq, 'ジャンル'
             %br

--- a/app/views/comics/_top-one.html.haml
+++ b/app/views/comics/_top-one.html.haml
@@ -17,7 +17,7 @@
           .search-box__word
             = f.label :search, '作品名から探せます'
             %br
-            = f.search_field :name_or_name_kana_or_author_name_cont, placeholder: "(例)犬夜叉"
+            = f.search_field :name_or_name_kana_cont, placeholder: "(例)犬夜叉"
           .search-box__word
             = f.label :search, '作者名から探せます'
             %br


### PR DESCRIPTION
# WHAT
 - 検索画面(search-screen)の仕様を少し変更
   - 作者検索、作品検索を同じフォームで行っていたが、分けて2つ用意した
   - 作品検索は、平仮名でも検索できるようにname_kanaカラムでもヒットさせる
 - 入力時（フォーカス）にデフォルトで青線が出て見栄え悪かった為、ユーザー登録時と同じように緑で囲むようにした
 - 変更後のビュー↓↓↓jz
<img width="1440" alt="スクリーンショット 2020-11-16 20 55 14" src="https://user-images.githubusercontent.com/69382240/99249819-087e7f00-284e-11eb-8b11-710af3024f68.png">



# WHY
 - 同じフォームだと、仮に「あ」と入力した際に「あ」のつく作品と作者が全て表示されてしまい、結果が多くなり、探しづらく感じた為