### PR TITLE
修正_3

### DIFF
--- a/app/assets/stylesheets/modules/authors.scss
+++ b/app/assets/stylesheets/modules/authors.scss
@@ -408,7 +408,12 @@
     padding: 40px;
     width: 850px;
     margin: 0 auto;
-
+    position: relative;
+    .comic__id {
+      position: absolute;
+      left: 20px;
+      top: 10px;
+    }
     &__box {
       position: relative;
       .comment_container {

--- a/app/controllers/authors_controller.rb
+++ b/app/controllers/authors_controller.rb
@@ -7,8 +7,8 @@ class AuthorsController < ApplicationController
     @comic_one = Comic.find_by(id: 1)
     @comic_two = Comic.find_by(id: 7)
     @comic_three = Comic.find_by(id: 3)
-    @comic_four = Comic.find_by(id: 4)
-    @comic_five = Comic.find_by(id: 5)
+    # @comic_four = Comic.find_by(id: 4)
+    # @comic_five = Comic.find_by(id: 5)
   end
 
   def new

--- a/app/controllers/comics_controller.rb
+++ b/app/controllers/comics_controller.rb
@@ -7,8 +7,8 @@ class ComicsController < ApplicationController
     @comic_one = Comic.find_by(id: 1)
     @comic_two = Comic.find_by(id: 7)
     @comic_three = Comic.find_by(id: 3)
-    @comic_four = Comic.find_by(id: 4)
-    @comic_five = Comic.find_by(id: 5)
+    # @comic_four = Comic.find_by(id: 4)
+    # @comic_five = Comic.find_by(id: 5)
   end
 
   def show
@@ -25,8 +25,8 @@ class ComicsController < ApplicationController
     @comic_one = Comic.find_by(id: 1)
     @comic_two = Comic.find_by(id: 7)
     @comic_three = Comic.find_by(id: 3)
-    @comic_four = Comic.find_by(id: 4)
-    @comic_five = Comic.find_by(id: 5)
+    # @comic_four = Comic.find_by(id: 4)
+    # @comic_five = Comic.find_by(id: 5)
   end
 
   def search      ##検索結果の画面c
@@ -38,8 +38,8 @@ class ComicsController < ApplicationController
     @comic_one = Comic.find_by(id: 1)
     @comic_two = Comic.find_by(id: 7)
     @comic_three = Comic.find_by(id: 3)
-    @comic_four = Comic.find_by(id: 4)
-    @comic_five = Comic.find_by(id: 5)
+    # @comic_four = Comic.find_by(id: 4)
+    # @comic_five = Comic.find_by(id: 5)
   end
 
   def recommend
@@ -50,8 +50,8 @@ class ComicsController < ApplicationController
     @comic_one = Comic.find_by(id: 1)
     @comic_two = Comic.find_by(id: 7)
     @comic_three = Comic.find_by(id: 3)
-    @comic_four = Comic.find_by(id: 4)
-    @comic_five = Comic.find_by(id: 5)
+    # @comic_four = Comic.find_by(id: 4)
+    # @comic_five = Comic.find_by(id: 5)
   end
 
   private

--- a/app/javascript/slideshow.js
+++ b/app/javascript/slideshow.js
@@ -13,7 +13,7 @@ $(window).on('load', ()=> {
     // 画像のスライドショー（タイマー単位はms）,演出はフェードインにする
     let num = 0;
     var slideshow_timer = function(){
-      if (num == 4){
+      if (num == 2){
           num = 0;
       }else {
           num ++;

--- a/app/views/authors/_side.html.haml
+++ b/app/views/authors/_side.html.haml
@@ -12,12 +12,12 @@
       - if @comic_three
         %li.slide__image.display_hide{data: { index: 2 }}
           = link_to image_tag(@comic_three.image.url, class: "side__up__image", id: "slideshow_three"), comic_path(id: @comic_three)
-      - if @comic_four
-        %li.slide__image.display_hide{data: { index: 3 }}
-          = link_to image_tag(@comic_four.image.url, class: "side__up__image", id: "slideshow_four"), comic_path(id: @comic_four)
-      - if @comic_five
-        %li.slide__image.display_hide{data: { index: 4 }}
-          = link_to image_tag(@comic_five.image.url, class: "side__up__image", id: "slideshow_five"), comic_path(id: @comic_five)
+      -# - if @comic_four       ## スライドショーの枚数を3枚にするのでｺﾒﾝﾄｱｳﾄしておく
+      -#   %li.slide__image.display_hide{data: { index: 3 }}
+      -#     = link_to image_tag(@comic_four.image.url, class: "side__up__image", id: "slideshow_four"), comic_path(id: @comic_four)
+      -# - if @comic_five
+      -#   %li.slide__image.display_hide{data: { index: 4 }}
+      -#     = link_to image_tag(@comic_five.image.url, class: "side__up__image", id: "slideshow_five"), comic_path(id: @comic_five)
     %ul.side__up__list
       %li.side__up__list__btn
         .circle__btn-box{data: { index: 0 }}
@@ -28,12 +28,12 @@
       %li.side__up__list__btn
         .circle__btn-box{data: { index: 2 }}
           = icon("fas", "circle", class: "circle__btn")
-      %li.side__up__list__btn
-        .circle__btn-box{data: { index: 3 }}
-          = icon("fas", "circle", class: "circle__btn")
-      %li.side__up__list__btn
-        .circle__btn-box{data: { index: 4 }}
-          = icon("fas", "circle", class: "circle__btn")
+      -# %li.side__up__list__btn
+      -#   .circle__btn-box{data: { index: 3 }}
+      -#     = icon("fas", "circle", class: "circle__btn")
+      -# %li.side__up__list__btn
+      -#   .circle__btn-box{data: { index: 4 }}
+      -#     = icon("fas", "circle", class: "circle__btn")
   .side__under
     %p
       %span お知らせ

--- a/app/views/comics/show.html.haml
+++ b/app/views/comics/show.html.haml
@@ -2,6 +2,10 @@
   = render 'authors/header'
   .top-show
     .main-show
+      - if user_signed_in? && current_user.admin?
+        %p.comic__id
+          ID:
+          =@comic.id
       .main-show__box
         %h3
           <<　作 品 情 報　>>


### PR DESCRIPTION
# WHAT
 - スライドショーの枚数を5枚から3枚に変更した。
 - 作品詳細画面(comic_show)に、管理者の場合のみ作品のIDを表示させた


# WHY
 - スライド5枚は多いため
 - スライドの作品を変更したい場合、コントローラでIDを変更するが、ブラウザのみでIDがわかるようにしたかったため、管理者で詳細画面を見た際はIDも表示させるようにした