### PR TITLE
漫画リクエスト機能の実装

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -7,4 +7,5 @@
 @import "modules/comics";
 @import "modules/users";
 @import "modules/comments";
-@import "modules/admins"
+@import "modules/admins";
+@import "modules/requests";

--- a/app/assets/stylesheets/modules/authors.scss
+++ b/app/assets/stylesheets/modules/authors.scss
@@ -674,6 +674,7 @@
 .wrapper__comic {
   display: block;
   background-color: #f5f5f5;
+  min-height: 100vh;
   height: auto;
   padding: 30px 0;
 
@@ -732,6 +733,11 @@
     .field_all {
       width: 600px;
       margin: 0 auto;
+      .request-info {   //リクエストフォームの説明文
+        margin-bottom: 15px;
+        font-size: 18px;
+        border-bottom: dashed 1px silver;
+      }
       .field {
         margin-bottom: 20px;
         span {

--- a/app/assets/stylesheets/modules/authors.scss
+++ b/app/assets/stylesheets/modules/authors.scss
@@ -169,6 +169,25 @@
           transform: rotateZ(180deg);
       }
         // ログイン中の表示CSS
+        .request__count {
+          margin-right: 20px;
+          border-radius: 50px;
+          position: relative;
+          i {
+            font-size: 25px;
+            color: #8d9977;
+          }
+          span {
+            background-color: red;
+            border-radius: 50%;
+            padding: 0 2px;
+            font-size: 10px;
+            color: white;
+            position: absolute;
+            right: -10px;
+            top: -5px;
+          }
+        }
         .current__user__name {
           line-height: 30px;
           margin-right: 20px;

--- a/app/assets/stylesheets/modules/requests.scss
+++ b/app/assets/stylesheets/modules/requests.scss
@@ -42,11 +42,6 @@
     }
 
     ul {
-      .search-result__count {
-        font-size: 20px;
-        margin-bottom: 40px;
-        padding-left: 50px;
-      }
       .requests__list {
         display: grid;
         grid-template-columns: repeat(3, 1fr);
@@ -58,6 +53,40 @@
             text-decoration: none;
             color: black;
           }
+        }
+      }
+    }
+    .display__list {
+      padding: 0 40px;
+      .request__UserName {
+        margin-bottom: 20px;
+        span { 
+          color: #1a73e8;
+          font-size: 20px;
+        }
+      }
+      .request__ComicName {
+        font-size: 22px;
+        margin-bottom: 20px;
+        span {
+          font-weight: bold;
+          font-size: 25px;
+        }
+      }
+      .request__AuthorName {
+        font-size: 22px;
+        margin-bottom: 20px;
+        span {
+          font-weight: bold;
+          font-size: 25px;
+        }
+      }
+      .request__Comment {
+        font-size: 22px;
+        margin-bottom: 20px;
+        p {
+          padding-left: 10px;
+          white-space: pre-wrap;
         }
       }
     }

--- a/app/assets/stylesheets/modules/requests.scss
+++ b/app/assets/stylesheets/modules/requests.scss
@@ -1,0 +1,65 @@
+// リクエスト一覧CSS
+
+.wrapper__request {
+  display: block;
+  background-color: #f5f5f5;
+  height: auto;
+  min-height: 100vh;
+  padding: 30px 0;
+
+  .header__user {
+    text-align: center;
+    .app-title__box {
+      font-size: 30px;
+      font-weight: bold;
+      text-align: center;
+      a {
+        padding: 20px;
+        background-color: #71dd9e;
+        border-radius: 50px;
+        color: white;
+        text-decoration: none;
+      }
+    }
+  }
+}
+
+.display__request {
+  background-color: white;
+  border: double 5px #ffc80036;
+  height: auto;
+  padding: 40px 40px;
+  margin: 40px auto 0;
+  width: 1000px;
+  min-height: 600px;
+
+  .request__box {
+    .requests__all {
+      font-size: 28px;
+      color: rgb(147, 224, 147);
+      margin-bottom: 30px;
+      padding-left: 40px;
+    }
+
+    ul {
+      .search-result__count {
+        font-size: 20px;
+        margin-bottom: 40px;
+        padding-left: 50px;
+      }
+      .requests__list {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        .comic-box__result {
+          border-bottom: dotted 1px #1a73e8;
+          margin: 0 10px;
+          padding: 10px;
+          a {
+            text-decoration: none;
+            color: black;
+          }
+        }
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/modules/requests.scss
+++ b/app/assets/stylesheets/modules/requests.scss
@@ -34,11 +34,26 @@
   min-height: 600px;
 
   .request__box {
-    .requests__all {
-      font-size: 28px;
-      color: rgb(147, 224, 147);
-      margin-bottom: 30px;
-      padding-left: 40px;
+    &__up {
+      display: flex;
+      justify-content: space-between;
+      .requests__all {
+        font-size: 28px;
+        color: rgb(147, 224, 147);
+        margin-bottom: 30px;
+        padding-left: 40px;
+      }
+      .request__delete {
+        a {
+          text-decoration: none;
+          color: black;
+          border: dotted 2px lightcoral;
+          padding: 5px;
+        }
+        a:hover {
+          color: lightcoral;
+        }
+      }
     }
 
     ul {
@@ -56,7 +71,7 @@
         }
       }
     }
-    .display__list {
+    .display__list {       //リクエスト詳細
       padding: 0 40px;
       .request__UserName {
         margin-bottom: 20px;

--- a/app/controllers/authors_controller.rb
+++ b/app/controllers/authors_controller.rb
@@ -9,6 +9,7 @@ class AuthorsController < ApplicationController
     @comic_three = Comic.find_by(id: 3)
     # @comic_four = Comic.find_by(id: 4)
     # @comic_five = Comic.find_by(id: 5)
+    @request_count = Request.all
   end
 
   def new

--- a/app/controllers/comics_controller.rb
+++ b/app/controllers/comics_controller.rb
@@ -9,6 +9,7 @@ class ComicsController < ApplicationController
     @comic_three = Comic.find_by(id: 3)
     # @comic_four = Comic.find_by(id: 4)
     # @comic_five = Comic.find_by(id: 5)
+    @request_count = Request.all
   end
 
   def show
@@ -27,6 +28,7 @@ class ComicsController < ApplicationController
     @comic_three = Comic.find_by(id: 3)
     # @comic_four = Comic.find_by(id: 4)
     # @comic_five = Comic.find_by(id: 5)
+    @request_count = Request.all
   end
 
   def search      ##検索結果の画面c
@@ -40,6 +42,7 @@ class ComicsController < ApplicationController
     @comic_three = Comic.find_by(id: 3)
     # @comic_four = Comic.find_by(id: 4)
     # @comic_five = Comic.find_by(id: 5)
+    @request_count = Request.all
   end
 
   def recommend
@@ -52,6 +55,7 @@ class ComicsController < ApplicationController
     @comic_three = Comic.find_by(id: 3)
     # @comic_four = Comic.find_by(id: 4)
     # @comic_five = Comic.find_by(id: 5)
+    @request_count = Request.all
   end
 
   private

--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -36,6 +36,7 @@ class RequestsController < ApplicationController
   end
 
   def show
+    @request = Request.find(params[:id])
   end
 
   private

--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -29,14 +29,22 @@ class RequestsController < ApplicationController
   end
 
   def destroy
-    @request = Request.find(params[:id])
-    if @request.destroy
+    if user_signed_in? && current_user.admin?
+      @request = Request.find(params[:id])
+      if @request.destroy
+        redirect_to root_path, notice: "削除しました"
+      end
+    else
       redirect_to root_path
     end
   end
 
   def show
-    @request = Request.find(params[:id])
+    if user_signed_in? && current_user.admin?
+      @request = Request.find(params[:id])
+    else
+      redirect_to root_path
+    end
   end
 
   private

--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -1,5 +1,10 @@
 class RequestsController < ApplicationController
   def index
+    if user_signed_in? && current_user.admin?
+      @requests = Request.all
+    else
+      redirect_to root_path
+    end
   end
 
   def new

--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -1,0 +1,40 @@
+class RequestsController < ApplicationController
+  def index
+  end
+
+  def new
+    if signed_in?
+      @request = Request.new
+    else
+      redirect_to root_path
+    end
+  end
+
+  def create
+    if signed_in?
+      @request = Request.new(request_params)
+      if @request.save
+        redirect_to root_path, notice: "要望を送信しました"
+      else
+        render :new
+      end
+    else
+      redirect_to root_path
+    end
+  end
+
+  def destroy
+    @request = Request.find(params[:id])
+    if @request.destroy
+      redirect_to root_path
+    end
+  end
+
+  def show
+  end
+
+  private
+  def request_params
+    params.require(:request).permit(:comicname, :authorname, :comment).merge(user_id: current_user.id)
+  end
+end

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -1,0 +1,6 @@
+class Request < ApplicationRecord
+  belongs_to :user
+  validates :comicname, presence: true
+  validates :authorname, presence: true
+  validates :comment, presence: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,4 +10,5 @@ class User < ApplicationRecord
   has_many :comics, through: :bookmarks
 
   has_many :comments, dependent: :destroy
+  has_many :request, dependent: :destroy
 end

--- a/app/views/authors/_header.html.haml
+++ b/app/views/authors/_header.html.haml
@@ -7,6 +7,11 @@
       %span 管理者のおすすめ漫画の紹介、備忘録なアプリとなっています。コメントもご自由にお書きください。
     .header__up__right
       %ul
+        - if user_signed_in? && current_user.admin?
+          %li.request__count
+            = icon("far", "bell")
+            %span
+              = @request_count.length
         - if user_signed_in?
           %li.current__user__name
             = current_user.name

--- a/app/views/authors/_header.html.haml
+++ b/app/views/authors/_header.html.haml
@@ -37,6 +37,10 @@
           .maru_btn
           = link_to user_showbookmark_path(current_user) do
             %p ブックマーク一覧
+        %li.menu_list
+          .maru_btn
+          = link_to new_user_request_path(current_user) do
+            %p 要望フォーム
         - if user_signed_in? && current_user.admin?
           %li.menu_list
             .maru_btn

--- a/app/views/authors/_header.html.haml
+++ b/app/views/authors/_header.html.haml
@@ -44,6 +44,10 @@
         - if user_signed_in? && current_user.admin?
           %li.menu_list
             .maru_btn
+            = link_to user_requests_path(current_user), class: "logout-btn btn" do
+              %p 要望一覧
+          %li.menu_list
+            .maru_btn
             = link_to new_author_path, class: "logout-btn btn" do
               %p 作品投稿
           %li.menu_list

--- a/app/views/requests/index.html.haml
+++ b/app/views/requests/index.html.haml
@@ -7,12 +7,12 @@
   .display__request
     %section.request__box
       %h2.requests__all 要望一覧
-      %ul.display__list
+      %ul
         - if @requests.present?
           .requests__list
             - @requests.each do |comic|
               %li.comic-box__result
-                = link_to "#" do
+                = link_to user_request_path(current_user, comic.id) do
                   = comic.comicname
         - else
           紹介依頼はありません

--- a/app/views/requests/index.html.haml
+++ b/app/views/requests/index.html.haml
@@ -1,0 +1,19 @@
+.wrapper__request
+
+  .header__user
+    %p.app-title__box
+      = link_to "Comic-Remember", root_path, class: "app-title"
+
+  .display__request
+    %section.request__box
+      %h2.requests__all 要望一覧
+      %ul.display__list
+        - if @requests.present?
+          .requests__list
+            - @requests.each do |comic|
+              %li.comic-box__result
+                = link_to "#" do
+                  = comic.comicname
+        - else
+          紹介依頼はありません
+          %div

--- a/app/views/requests/new.html.haml
+++ b/app/views/requests/new.html.haml
@@ -1,0 +1,29 @@
+.wrapper__comic
+
+  .header__comic
+    %p.app-title__box
+      = link_to "Comic-Remember", root_path, class: "app-title"
+  .main__comic-box
+    %section.main__comic-box__center
+      %h2 要望フォーム
+      = form_with model: @request, :url => {:action => :create}, html: {class: "Form"}, local: true do |a|
+        .field_all
+          %p.request-info 紹介作品以外で、紹介を希望する作品があればこちらから要望ください。
+          .field
+            = a.label :comicname, "作品名"
+            %br
+            = a.text_field :comicname, class: "form_default", required: true, placeholder: "例）アライブ 最終進化的少年"
+            %br
+          .field
+            = a.label :authorname, "作者名"
+            %span （作者が2名以上いる場合は続けてご入力ください）
+            %br
+            = a.text_field :authorname, class: "form_default", required: true, placeholder: "例）河島正 × あだちとか"
+            %br
+          .field
+            = a.label :comment, "おすすめポイント"
+            %br
+            = a.text_area :comment, class: "form_review", required: true, placeholder: "3つ程おすすめポイントをお書きください"
+            %br
+          .actions
+            = a.submit "送信する", class: "form_submit"

--- a/app/views/requests/show.html.haml
+++ b/app/views/requests/show.html.haml
@@ -1,0 +1,27 @@
+.wrapper__request
+
+  .header__user
+    %p.app-title__box
+      = link_to "Comic-Remember", root_path, class: "app-title"
+
+  .display__request
+    %section.request__box
+      %h2.requests__all 要望詳細
+      .display__list
+        .request__UserName
+          %span
+            = @request.user.name
+          さんからの紹介希望
+        .request__ComicName
+          作品：
+          %span
+            = @request.comicname
+        .request__AuthorName
+          作者：
+          %span
+            = @request.authorname
+        .request__Comment
+          おすすめポイント
+          %p
+            = @request.comment
+

--- a/app/views/requests/show.html.haml
+++ b/app/views/requests/show.html.haml
@@ -6,7 +6,10 @@
 
   .display__request
     %section.request__box
-      %h2.requests__all 要望詳細
+      .request__box__up
+        %h2.requests__all 要望詳細
+        .request__delete
+          = link_to "削除する", user_request_path(current_user, @request), data: { confirm: "紹介依頼を削除しますか？" }, method: :delete, class: "request__delete__btn" , id: "request_delete_button", value: "削除する"
       .display__list
         .request__UserName
           %span

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,5 +24,6 @@ Rails.application.routes.draw do
   resources :authors
   resources :users, only: :show do
     get 'showbookmark'
+    resources :requests, only: [:index, :new, :create, :destroy, :show]
   end
 end

--- a/db/migrate/20201123022016_create_requests.rb
+++ b/db/migrate/20201123022016_create_requests.rb
@@ -1,0 +1,11 @@
+class CreateRequests < ActiveRecord::Migration[6.0]
+  def change
+    create_table :requests do |t|
+      t.string :comicname, null: false
+      t.string :authorname, null: false
+      t.text :comment, null: false
+      t.references :user, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_10_054826) do
+ActiveRecord::Schema.define(version: 2020_11_23_022016) do
 
   create_table "authors", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -68,6 +68,16 @@ ActiveRecord::Schema.define(version: 2020_11_10_054826) do
     t.index ["genre"], name: "index_genres_on_genre", unique: true
   end
 
+  create_table "requests", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "comicname", null: false
+    t.string "authorname", null: false
+    t.text "comment", null: false
+    t.bigint "user_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_requests_on_user_id"
+  end
+
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
     t.string "email", default: "", null: false
@@ -90,4 +100,5 @@ ActiveRecord::Schema.define(version: 2020_11_10_054826) do
   add_foreign_key "comics", "authors"
   add_foreign_key "comments", "comics"
   add_foreign_key "comments", "users"
+  add_foreign_key "requests", "users"
 end


### PR DESCRIPTION
# WHAT
 - 漫画のリクエスト機能を実装した
   - 内容は、作品、作者、推すポイントの3点にする
 - メーラー機能も考えたがメールを送るほどではないため、MVCの流れで完結させるようにした
   - 必要性がでてくればメール機能も追加すること
 - 管理者のトップ画面に、ベルマーク追加して要望があった場合は確認できるようにした
 - ドロワーメニューに要望フォームへのリンクを追加
   - 管理者のドロワーメニューには、要望一覧も追加
     - クリックで一覧ページ→作品クリックでその詳細画面へ遷移→削除も可能
  - デザイン
<img width="1440" alt="スクリーンショット 2020-11-23 17 30 09" src="https://user-images.githubusercontent.com/69382240/99941697-ce632f00-2db1-11eb-8e45-6724a7bffdd0.png">
<img width="1440" alt="スクリーンショット 2020-11-23 17 29 59" src="https://user-images.githubusercontent.com/69382240/99941698-d02cf280-2db1-11eb-99fc-91c46edeea39.png">


# WHY
 - 利用者がこのアプリ内で紹介してほしい作品があった場合、管理者に要望をだす機能があったほうが良いため
 - 管理者の知らない作品を共有して欲しいため