### PR TITLE
修正_5

### DIFF
--- a/app/controllers/authors_controller.rb
+++ b/app/controllers/authors_controller.rb
@@ -28,7 +28,7 @@ class AuthorsController < ApplicationController
       end
       comic = Comic.new(comic_params)
       comic.save!
-      redirect_to root_path
+      redirect_to root_path, notice: "作品を登録しました"
     else
       redirect_to root_path
     end
@@ -78,7 +78,7 @@ class AuthorsController < ApplicationController
           @comic.update(update_author_db_find_comic_params)
         end
       end
-      redirect_to root_path
+      redirect_to root_path, notice: "作品情報を更新しました"
     else
       redirect_to root_path
     end
@@ -93,7 +93,7 @@ class AuthorsController < ApplicationController
         comic = Comic.find_by(name: params[:format])
         comic.destroy
       end
-      redirect_to root_path
+      redirect_to root_path, notice: "作品を削除しました"
     else
       redirect_to root_path
     end

--- a/app/views/authors/_main.html.haml
+++ b/app/views/authors/_main.html.haml
@@ -2,7 +2,7 @@
   .select
     %ul.select__list
       %li.list__type.recommend
-        = link_to "おすすめ", recommend_comics_path
+        = link_to "おすすめ", root_path
       %li.list__type.comic
         = link_to "作品一覧", comics_path
       %li.list__type.author

--- a/app/views/comics/_top-four.html.haml
+++ b/app/views/comics/_top-four.html.haml
@@ -3,7 +3,7 @@
     .select
       %ul.select__list
         %li.list__type.recommend
-          = link_to "おすすめ", recommend_comics_path
+          = link_to "おすすめ", root_path
         %li.list__type.comic
           = link_to "作品一覧", comics_path
         %li.list__type.author

--- a/app/views/comics/_top-one.html.haml
+++ b/app/views/comics/_top-one.html.haml
@@ -3,7 +3,7 @@
     .select
       %ul.select__list
         %li.list__type.recommend
-          = link_to "おすすめ", recommend_comics_path
+          = link_to "おすすめ", root_path
         %li.list__type.comic
           = link_to "作品一覧", comics_path
         %li.list__type.author

--- a/app/views/comics/_top-three.html.haml
+++ b/app/views/comics/_top-three.html.haml
@@ -3,7 +3,7 @@
     .select
       %ul.select__list
         %li.list__type.recommend
-          = link_to "おすすめ", comics_path
+          = link_to "おすすめ", root_path
         %li.list__type.comic
           = link_to "作品一覧", comics_path
         %li.list__type.author

--- a/app/views/comics/_top-two.html.haml
+++ b/app/views/comics/_top-two.html.haml
@@ -3,7 +3,7 @@
     .select
       %ul.select__list
         %li.list__type.recommend
-          = link_to "おすすめ", recommend_comics_path
+          = link_to "おすすめ", root_path
         %li.list__type.comic
           = link_to "作品一覧", comics_path
         %li.list__type.author

--- a/app/views/comics/show.html.haml
+++ b/app/views/comics/show.html.haml
@@ -56,7 +56,7 @@
           %div
             = @comic.summary
         .show__review
-          %span 管理者から一言
+          %span 管理者コメント
           .show__review__box
             .show__review__box__icon
               = icon('fas', 'user-graduate', class: 'admin-icon')


### PR DESCRIPTION
# WHAT
 - 細かい修正、追加をした
   - 作品の投稿、編集、削除時にflash_messageが流れるようにした
   - トップ画面のタブ(おすすめ、作品、作者、検索)でおすすめのリンクがrecommendになっていたため、root_pathに修正（挙動は同じだが、URLに違和感があるため修正）
   - タブを作品一覧にしたときに、おすすめタブをクリックするとおすすめではなく、作品にlinkがなっていたため、root(recommend)に修正
   - 作品詳細画面の「管理者の一言」を「管理者コメント」に修正（一言ではなかったため）


# WHY
 - アプリの修正箇所の確認は必須
 - 使い勝手向上のため、修正